### PR TITLE
activate defaultNoRuleRes support

### DIFF
--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/AbstractMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/AbstractMaskingProvider.java
@@ -5,10 +5,6 @@
  */
 package com.ibm.whc.deid.providers.masking;
 
-import java.io.Serializable;
-import java.security.SecureRandom;
-import java.util.List;
-import java.util.Map;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -18,13 +14,16 @@ import com.ibm.whc.deid.schema.FieldRelationship;
 import com.ibm.whc.deid.shared.pojo.masking.ReferableData;
 import com.ibm.whc.deid.utils.log.LogCodes;
 import com.ibm.whc.deid.utils.log.LogManager;
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Map;
 
 /**
  * The type Abstract masking provider.
  *
  */
-public abstract class AbstractMaskingProvider implements MaskingProvider, Serializable {
-  /** */
+public abstract class AbstractMaskingProvider implements MaskingProvider {
+
   private static final long serialVersionUID = -6276716005726979282L;
 
   protected SecureRandom random;
@@ -89,6 +88,7 @@ public abstract class AbstractMaskingProvider implements MaskingProvider, Serial
    *
    * @param logManager the log manager
    */
+  @Override
   public void setTestingOnlyLogManager(LogManager logManager) {
     testingOnly_LogManager = logManager;
   }
@@ -121,10 +121,11 @@ public abstract class AbstractMaskingProvider implements MaskingProvider, Serial
     if (i.getParent().isObject()) {
       i.setParent(((ObjectNode) i.getParent()).set(i.getPath(), new TextNode(value)));
     } else if (i.getParent().isArray()) {
-      ArrayNode aNode = (ArrayNode) i.getParent();
+      ArrayNode aNode = (ArrayNode)i.getParent();
       int indexOfResult = -1;
-      for (int currentIndex = 0; currentIndex < aNode.size(); currentIndex++) {
-        if (aNode.get(currentIndex).equals(i.getNode())) {
+      int size = aNode.size();
+      for (int currentIndex = 0; currentIndex < size; currentIndex++) {
+        if (aNode.get(currentIndex) == i.getNode()) {
           indexOfResult = currentIndex;
           break;
         }
@@ -133,10 +134,12 @@ public abstract class AbstractMaskingProvider implements MaskingProvider, Serial
     }
   }
 
+  @Override
   public void setName(String name) {
     this.name = name;
   }
 
+  @Override
   public String getName() {
     return name;
   }

--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/MaintainMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/MaintainMaskingProvider.java
@@ -5,10 +5,17 @@
  */
 package com.ibm.whc.deid.providers.masking;
 
+import com.ibm.whc.deid.providers.masking.fhir.MaskingActionInputIdentifier;
+import java.util.List;
+
 public class MaintainMaskingProvider extends AbstractMaskingProvider {
 
-	/** */
-	private static final long serialVersionUID = -1799896601470556794L;
+  private static final long serialVersionUID = -1799896601470556794L;
+
+  @Override
+  public void maskIdentifierBatch(List<MaskingActionInputIdentifier> identifiers) {
+    // override superclass to retain data type of original node
+  }
 
   @Override
   public String mask(String identifier) {

--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/fhir/FHIRMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/fhir/FHIRMaskingProvider.java
@@ -22,7 +22,7 @@ import com.ibm.whc.deid.utils.log.LogCodes;
 import scala.Tuple2;
 
 public class FHIRMaskingProvider extends AbstractComplexMaskingProvider<String> {
-  /** */
+
   private static final long serialVersionUID = 5945527984023679481L;
 
   private List<String> copyFieldList = new ArrayList<String>();
@@ -30,12 +30,13 @@ public class FHIRMaskingProvider extends AbstractComplexMaskingProvider<String> 
   public FHIRMaskingProvider(DeidMaskingConfig maskingConfiguration,
       MaskingProviderFactory maskingProviderFactory, String tenantId) {
     this(maskingConfiguration, maskingConfiguration.getCertificateId(), true,
-        true, maskingProviderFactory, "/fhir/", tenantId);
+        maskingConfiguration.isDefaultNoRuleResolution(), maskingProviderFactory, "/fhir/",
+        tenantId);
   }
 
-  protected FHIRMaskingProvider(DeidMaskingConfig maskingConfiguration,
-      String certificateId, boolean arrayAllRules, boolean defNoRuleRes,
-      MaskingProviderFactory maskingProviderFactory, String basePathPrefix, String tenantId) {
+  protected FHIRMaskingProvider(DeidMaskingConfig maskingConfiguration, String certificateId,
+      boolean arrayAllRules, boolean defNoRuleRes, MaskingProviderFactory maskingProviderFactory,
+      String basePathPrefix, String tenantId) {
     super(maskingConfiguration);
 
     this.maskingProviderFactory = maskingProviderFactory;
@@ -99,8 +100,8 @@ public class FHIRMaskingProvider extends AbstractComplexMaskingProvider<String> 
     this.copyFieldList = copyFieldList;
   }
 
-  public List<ReferableData> maskWithBatch(List<ReferableData> payloadData,
-      String jobId) {
+  @Override
+  public List<ReferableData> maskWithBatch(List<ReferableData> payloadData, String jobId) {
     List<Tuple2<String, JsonNode>> toMask = payloadData.stream().map(input -> {
       JsonNode node = null;
       try {

--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/fhir/GenericMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/fhir/GenericMaskingProvider.java
@@ -9,7 +9,7 @@ import com.ibm.whc.deid.providers.masking.MaskingProviderFactory;
 import com.ibm.whc.deid.shared.pojo.config.DeidMaskingConfig;
 
 public class GenericMaskingProvider extends FHIRMaskingProvider {
-  /** */
+
   private static final long serialVersionUID = 5945527984023679481L;
 
   private static final String BASE_PATH_PREFIX = "/gen/";
@@ -17,13 +17,13 @@ public class GenericMaskingProvider extends FHIRMaskingProvider {
   public GenericMaskingProvider(DeidMaskingConfig maskingConfiguration,
       MaskingProviderFactory maskingProviderFactory, String tenantId) {
     this(maskingConfiguration, maskingConfiguration.getCertificateId(), true,
-        true, maskingProviderFactory, tenantId);
+        maskingConfiguration.isDefaultNoRuleResolution(), maskingProviderFactory, tenantId);
   }
 
-  public GenericMaskingProvider(DeidMaskingConfig maskingConfiguration,
-      String certificateId, boolean arrayAllRules, boolean defNoRuleRes,
-      MaskingProviderFactory maskingProviderFactory, String tenantId) {
-    super(maskingConfiguration, certificateId, arrayAllRules, defNoRuleRes,
-        maskingProviderFactory, BASE_PATH_PREFIX, tenantId);
+  public GenericMaskingProvider(DeidMaskingConfig maskingConfiguration, String certificateId,
+      boolean arrayAllRules, boolean defNoRuleRes, MaskingProviderFactory maskingProviderFactory,
+      String tenantId) {
+    super(maskingConfiguration, certificateId, arrayAllRules, defNoRuleRes, maskingProviderFactory,
+        BASE_PATH_PREFIX, tenantId);
   }
 }

--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/fhir/MaskingActionInputIdentifier.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/fhir/MaskingActionInputIdentifier.java
@@ -10,9 +10,9 @@ import com.ibm.whc.deid.providers.masking.MaskingProvider;
 
 public class MaskingActionInputIdentifier {
 
-  MaskingProvider provider;
+  private MaskingProvider provider;
 
-  JsonNode node;
+  private JsonNode node;
 
   private JsonNode parent;
 
@@ -23,6 +23,18 @@ public class MaskingActionInputIdentifier {
   private String resourceType;
 
   private JsonNode root;
+
+  public MaskingActionInputIdentifier(MaskingProvider provider, JsonNode node, JsonNode parent,
+      String path, String resourceType, String resourceId, JsonNode root) {
+    super();
+    this.provider = provider;
+    this.node = node;
+    this.parent = parent;
+    this.path = path;
+    this.resourceId = resourceId;
+    this.resourceType = resourceType;
+    this.root = root;
+  }
 
   public MaskingProvider getProvider() {
     return provider;
@@ -38,22 +50,6 @@ public class MaskingActionInputIdentifier {
 
   public void setNode(JsonNode node) {
     this.node = node;
-  }
-
-  public MaskingActionInputIdentifier(MaskingProvider provider, JsonNode node, JsonNode parent,
-      String path, String resourceType, String resourceId, JsonNode root) {
-    super();
-    this.provider = provider;
-    this.node = node;
-    this.parent = parent;
-    this.path = path;
-    this.resourceId = resourceId;
-    this.resourceType = resourceType;
-    this.root = root;
-  }
-
-  public boolean isArray() {
-    return path == null;
   }
 
   public JsonNode getParent() {

--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/util/NoRuleManager.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/util/NoRuleManager.java
@@ -1,0 +1,110 @@
+/*
+ * (C) Copyright IBM Corp. 2016,2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.whc.deid.providers.masking.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ibm.whc.deid.providers.masking.MaskingProvider;
+import com.ibm.whc.deid.providers.masking.fhir.MaskingActionInputIdentifier;
+import com.ibm.whc.deid.providers.masking.fhir.MaskingProviderBuilder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+
+/**
+ * Tracks the leaf nodes of a JSON document that are masked during masking processing so that
+ * remaining leaf nodes can be processed by the provider designated for "defaultNoRuleRes".
+ */
+public class NoRuleManager {
+
+  private MaskingProvider noRuleResProvider;
+
+  private class JsonNodeMapWrapper {
+
+    private final JsonNode node;
+
+    public JsonNodeMapWrapper(JsonNode n) {
+      node = n;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof JsonNodeMapWrapper && this.node == ((JsonNodeMapWrapper) o).node;
+    }
+
+    @Override
+    public int hashCode() {
+      return node.hashCode();
+    }
+  }
+
+  private HashMap<JsonNodeMapWrapper, MaskingActionInputIdentifier> map = new HashMap<>(1000);
+
+  public NoRuleManager(MaskingProviderBuilder.MaskingResource maskingResource, String resourceId,
+      MaskingProvider noRuleResProvider) {
+    this.noRuleResProvider = noRuleResProvider;
+    findLeaves(maskingResource.getJsonNode(), "", maskingResource.getJsonNode(), resourceId,
+        maskingResource.getResourceType());
+  }
+
+  public void removeNodesAlreadyMasked(List<MaskingActionInputIdentifier> listToMaskPerResource) {
+    if (listToMaskPerResource != null) {
+      for (MaskingActionInputIdentifier inputIdentifier : listToMaskPerResource) {
+        JsonNode maskedNode = inputIdentifier.getNode();
+        if (maskedNode != null) {
+          map.remove(new JsonNodeMapWrapper(maskedNode));
+        }
+      }
+    }
+  }
+
+  public void applyToRemainingNodes() {
+    List<MaskingActionInputIdentifier> list = new ArrayList<>(map.values());
+    noRuleResProvider.maskIdentifierBatch(list);
+  }
+
+  private void findLeaves(JsonNode rootNode, String parentPath, JsonNode parentNode,
+      String resourceId, String resourceType) {
+    if (parentNode != null && !parentNode.isNull()) {
+
+      if (parentNode.isArray()) {
+        int size = parentNode.size();
+        for (int i = 0; i < size; i++) {
+          JsonNode childNode = parentNode.get(i);
+          if (!childNode.isNull()) {
+            StringBuilder buffer = new StringBuilder(parentPath.length() + 10);
+            buffer.append(parentPath).append('[').append(i).append(']');
+            String childPath = buffer.toString();
+            if (childNode.isArray() || childNode.isObject()) {
+              findLeaves(rootNode, childPath, childNode, resourceId, resourceType);
+            } else {
+              map.put(new JsonNodeMapWrapper(childNode),
+                  new MaskingActionInputIdentifier(noRuleResProvider, childNode, parentNode,
+                      childPath, resourceType, resourceId, rootNode));
+            }
+          }
+        }
+
+      } else if (parentNode.isObject()) {
+        Iterator<Entry<String, JsonNode>> it = parentNode.fields();
+        while (it.hasNext()) {
+          Entry<String, JsonNode> entry = it.next();
+          JsonNode childNode = entry.getValue();
+          if (childNode.isNull()) {
+            continue;
+          } else if (childNode.isArray() || childNode.isObject()) {
+            findLeaves(rootNode, entry.getKey(), childNode, resourceId, resourceType);
+          } else {
+            map.put(new JsonNodeMapWrapper(childNode),
+                new MaskingActionInputIdentifier(noRuleResProvider, childNode, parentNode,
+                    entry.getKey(), resourceType, resourceId, rootNode));
+          }
+        }
+      }
+    }
+  }
+}

--- a/ipv-core/src/test/java/com/ibm/whc/deid/masking/DataMaskingCoreTest2.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/masking/DataMaskingCoreTest2.java
@@ -1,0 +1,150 @@
+/*
+ * (C) Copyright IBM Corp. 2016,2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.whc.deid.masking;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import com.ibm.whc.deid.shared.pojo.config.ConfigSchemaType;
+import com.ibm.whc.deid.shared.pojo.masking.ReferableData;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+public class DataMaskingCoreTest2 {
+
+  @Test
+  public void testIdenticalStringArrayMasking() throws Exception {
+    DataMaskingCore dataMask = new DataMaskingCore();
+
+    String config = readStringResource("/config/identical-array.json");
+
+    List<String> inputList = new ArrayList<>();
+    inputList.add(readStringResource("/data/identical-array.json"));
+
+    List<ReferableData> maskedDataList =
+        dataMask.maskData(config, convertList(inputList), ConfigSchemaType.GEN);
+
+    assertEquals(1, maskedDataList.size());
+    assertEquals(
+        "{\"address\":[{\"line\":[null,\"XXXXXXXXXXXXXXXXXXXXXXXXXXXX\",null,\"3300 University Dr, Suite 19\"]}]}",
+        maskedDataList.get(0).getData());
+  }
+
+  @Test
+  public void testInvalidPathNotLeaf() throws Exception {
+    String config = readStringResource("/config/pathNotLeaf.config.json");
+
+    List<String> inputList = new ArrayList<>();
+    inputList.add(readStringResource("/data/pathNotLeaf.leaf.json"));
+    inputList.add(readStringResource("/data/pathNotLeaf.array.json"));
+    inputList.add(readStringResource("/data/pathNotLeaf.nested-array.json"));
+    inputList.add(readStringResource("/data/pathNotLeaf.object.json"));
+    inputList.add(readStringResource("/data/pathNotLeaf.mixed-array.json"));
+
+    String resultLeaf = readStringResource("/result/pathNotLeaf.result.leaf.json");
+    String resultArray = readStringResource("/result/pathNotLeaf.result.array.json");
+    String resultNestedArray = readStringResource("/result/pathNotLeaf.result.nested-array.json");
+    String resultObject = readStringResource("/result/pathNotLeaf.result.object.json");
+    String resultMixedArray = readStringResource("/result/pathNotLeaf.result.mixed-array.json");
+
+    DataMaskingCore dataMask = new DataMaskingCore();
+    List<ReferableData> maskedDataList =
+        dataMask.maskData(config, convertList(inputList), ConfigSchemaType.FHIR);
+
+    assertEquals(5, maskedDataList.size());
+    assertEquals(resultLeaf, maskedDataList.get(0).getData());
+    assertEquals(resultArray, maskedDataList.get(1).getData());
+    assertEquals(resultNestedArray, maskedDataList.get(2).getData());
+    assertEquals(resultObject, maskedDataList.get(3).getData());
+    assertEquals(resultMixedArray, maskedDataList.get(4).getData());
+  }
+
+  @Test
+  public void testInvalidPathNotLeaf_noRule() throws Exception {
+    String config = readStringResource("/config/pathNotLeaf.norule.config.json");
+
+    List<String> inputList = new ArrayList<>();
+    inputList.add(readStringResource("/data/pathNotLeaf.leaf.json"));
+    inputList.add(readStringResource("/data/pathNotLeaf.array.json"));
+    inputList.add(readStringResource("/data/pathNotLeaf.nested-array.json"));
+    inputList.add(readStringResource("/data/pathNotLeaf.object.json"));
+    inputList.add(readStringResource("/data/pathNotLeaf.mixed-array.json"));
+
+    String resultLeaf = readStringResource("/result/pathNotLeaf.result.norule.leaf.json");
+    String resultArray = readStringResource("/result/pathNotLeaf.result.norule.array.json");
+    String resultNestedArray = readStringResource("/result/pathNotLeaf.result.norule.nested-array.json");
+    String resultObject = readStringResource("/result/pathNotLeaf.result.norule.object.json");
+    String resultMixedArray = readStringResource("/result/pathNotLeaf.result.norule.mixed-array.json");
+
+    DataMaskingCore dataMask = new DataMaskingCore();
+    List<ReferableData> maskedDataList =
+        dataMask.maskData(config, convertList(inputList), ConfigSchemaType.FHIR);
+
+    assertEquals(5, maskedDataList.size());
+    assertEquals(resultLeaf, maskedDataList.get(0).getData());
+    assertEquals(resultArray, maskedDataList.get(1).getData());
+    assertEquals(resultNestedArray, maskedDataList.get(2).getData());
+    assertEquals(resultObject, maskedDataList.get(3).getData());
+    assertEquals(resultMixedArray, maskedDataList.get(4).getData());
+  }
+
+  @Test
+  public void testNoRule_ResourceTypes() throws Exception {
+    String config = readStringResource("/config/defNoRuleRes.config.json");
+
+    List<String> inputList = new ArrayList<>();
+    inputList.add(readStringResource("/data/defNoRuleRes.type-listed-no-rules.json"));
+    inputList.add(readStringResource("/data/defNoRuleRes.type-not-listed.json"));
+    inputList.add(readStringResource("/data/defNoRuleRes.type-not-present.json"));
+    List<ReferableData> convertedList = convertList(inputList);
+    
+    String resultListed = readStringResource("/result/defNoRuleRes.result.type-listed-no-rules.json");
+    String resultNotListed = readStringResource("/result/defNoRuleRes.result.type-not-listed.json");
+    String resultNotPresent = readStringResource("/result/defNoRuleRes.result.type-not-present.json");
+
+    DataMaskingCore dataMask = new DataMaskingCore();
+    List<ReferableData> maskedDataList = dataMask.maskData(config, convertedList, ConfigSchemaType.FHIR);
+
+    assertEquals(3, maskedDataList.size());
+    boolean foundListed = false;
+    boolean foundNotListed = false;
+    boolean foundNotPresent = false;
+    for (ReferableData rd : maskedDataList) {
+      String result = rd.getData();
+      if (result.contains("Unknown")) {
+        assertEquals(resultNotPresent, result);
+        foundNotPresent = true;
+      } else if (rd.getData().contains("Device")) {
+        assertEquals(resultNotListed, result);
+        foundNotListed = true;
+      } else {
+        assertEquals(resultListed, result);
+        foundListed = true;
+      }
+    }
+    assertTrue(foundListed);
+    assertTrue(foundNotListed);
+    assertTrue(foundNotPresent);
+  }
+
+  private List<ReferableData> convertList(List<String> inputList) {
+    return inputList.stream().map(input -> {
+      return new ReferableData(input);
+    }).collect(Collectors.toList());
+  }
+
+  private String readStringResource(String path) throws IOException, URISyntaxException {
+    return new String(Files.readAllBytes(Paths.get(getClass().getResource(path).toURI())),
+        StandardCharsets.UTF_8);
+  }
+
+}

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/util/NoRuleManagerTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/util/NoRuleManagerTest.java
@@ -1,0 +1,94 @@
+/*
+ * (C) Copyright IBM Corp. 2016,2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.whc.deid.providers.masking.util;
+
+import static org.junit.Assert.assertEquals;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.ibm.whc.deid.ObjectMapperFactory;
+import com.ibm.whc.deid.providers.masking.fhir.MaskingActionInputIdentifier;
+import com.ibm.whc.deid.providers.masking.fhir.MaskingProviderBuilder;
+import com.ibm.whc.deid.providers.masking.fhir.NullMaskingProvider;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class NoRuleManagerTest {
+
+  @Test
+  public void testMain() throws Exception {
+    NullMaskingProvider provider = new NullMaskingProvider();
+    ObjectMapper om = ObjectMapperFactory.getObjectMapper();
+
+    StringBuilder buffer = new StringBuilder(100);
+    buffer.append("{");
+    buffer.append("\"resourceType\": \"Organization\",");
+    buffer.append("\"id\": \"4\",");
+    buffer.append("\"address\": [");
+    buffer.append("    {\"line\": [");
+    buffer.append("       \"v101\",");
+    buffer.append("       \"v102\",");
+    buffer.append("       \"v101\",");
+    buffer.append("       \"v103\",");
+    buffer.append("       null,");
+    buffer.append("       {\"a\":1, \"b\":2},");
+    buffer.append("       [\"box1\", \"box2\"],");
+    buffer.append("       [{\"c\":3, \"d\":4, \"e\":null}]");
+    buffer.append("] } ] }");
+    String doc = buffer.toString();
+
+    JsonNode root = om.readTree(doc);
+    NoRuleManager mgr = new NoRuleManager(
+        new MaskingProviderBuilder.MaskingResource("id", root, null), "r1", provider);
+    mgr.applyToRemainingNodes();
+    assertEquals(
+        "{\"resourceType\":null,\"id\":null,\"address\":[{\"line\":[null,null,null,null,null,{\"a\":null,\"b\":null},[null,null],[{\"c\":null,\"d\":null,\"e\":null}]]}]}",
+        om.writeValueAsString(root));
+
+    root = om.readTree(doc);
+    mgr = new NoRuleManager(new MaskingProviderBuilder.MaskingResource("id", root, null), "r1",
+        provider);
+    JsonNode branchNode = root.get("address");
+    JsonNode otherNode = om.readTree("{\"a\":1}");
+    JsonNode lineNode = root.get("address").get(0).get("line");
+    JsonNode childNode = lineNode.get(2);
+    JsonNode cParentNode = root.get("address").get(0).get("line").get(7).get(0);
+    JsonNode cNode = cParentNode.get("c");
+    JsonNode eNode = cParentNode.get("e");
+    List<MaskingActionInputIdentifier> list = new ArrayList<>();
+    // not leaf, ignored
+    list.add(new MaskingActionInputIdentifier(null, branchNode, root, "address", "Organization",
+        "r2", root));
+    // created by masking actions, not an original node
+    list.add(new MaskingActionInputIdentifier(null, otherNode, root, "address", "Organization",
+        "r2", root));
+    // original array node
+    list.add(new MaskingActionInputIdentifier(null, childNode, lineNode, "line[2]", "Organization",
+        "r2", root));
+    // original node
+    list.add(new MaskingActionInputIdentifier(null, cNode, cParentNode, "c", "Organization",
+        "r2", root));
+    // already null node
+    list.add(new MaskingActionInputIdentifier(null, eNode, cParentNode, "e", "Organization",
+        "r2", root));    
+    mgr.removeNodesAlreadyMasked(list);
+    mgr.applyToRemainingNodes();
+    assertEquals(
+        "{\"resourceType\":null,\"id\":null,\"address\":[{\"line\":[null,null,\"v101\",null,null,{\"a\":null,\"b\":null},[null,null],[{\"c\":3,\"d\":null,\"e\":null}]]}]}",
+        om.writeValueAsString(root));
+    
+    //root is value node - not supported by system
+    JsonNode valueRoot = new TextNode("lion");
+    mgr = new NoRuleManager(new MaskingProviderBuilder.MaskingResource("id", valueRoot, null), "r3",
+        provider);
+    list.clear();
+    list.add(new MaskingActionInputIdentifier(null, valueRoot, valueRoot, "", "", "r3", valueRoot));
+    mgr.removeNodesAlreadyMasked(list);
+    mgr.applyToRemainingNodes();
+    assertEquals("\"lion\"", om.writeValueAsString(valueRoot));
+  }
+}

--- a/ipv-core/src/test/resources/config/defNoRuleRes.config.json
+++ b/ipv-core/src/test/resources/config/defNoRuleRes.config.json
@@ -1,0 +1,27 @@
+{
+    "defaultNoRuleResolution": false,
+	"rules": [
+		{
+			"name": "maintainRule",
+			"maskingProviders": [
+				{
+					"type": "MAINTAIN"
+				}
+			]
+		}
+	],
+	"json": {
+		"schemaType": "FHIR",
+		"messageTypeKey": "resourceType",
+		"messageTypes": [
+			"Patient", "Organization"
+		],
+		"maskingRules": [
+			{
+				"jsonPath": "/fhir/Organization/address/line",
+				"rule": "maintainRule"
+			}
+		]
+	}
+}
+    

--- a/ipv-core/src/test/resources/config/identical-array.json
+++ b/ipv-core/src/test/resources/config/identical-array.json
@@ -1,0 +1,35 @@
+{
+	"defaultNoRuleResolution": false,
+	"rules": [
+		{
+			"name": "redactRule",
+			"maskingProviders": [
+				{
+					"type": "REDACT"
+				}
+			]
+		},
+		{
+			"name": "maintainRule",
+			"maskingProviders": [
+				{
+					"type": "MAINTAIN"
+				}
+			]
+		}
+	],
+	"json": {
+		"schemaType": "GEN",
+		"maskingRules": [
+			{
+				"jsonPath": "/gen/default/address/line[1]",
+				"rule": "redactRule"
+			},
+			{
+				"jsonPath": "/gen/default/address/line[3]",
+				"rule": "maintainRule"
+			}
+		]
+	}
+}
+	

--- a/ipv-core/src/test/resources/config/pathNotLeaf.config.json
+++ b/ipv-core/src/test/resources/config/pathNotLeaf.config.json
@@ -1,0 +1,26 @@
+{
+	"rules": [
+		{
+			"name": "redactRule",
+			"maskingProviders": [
+				{
+					"type": "REDACT"
+				}
+			]
+		}
+	],
+	"json": {
+		"schemaType": "FHIR",
+		"messageTypeKey": "resourceType",
+		"messageTypes": [
+			"Organization"
+		],
+		"maskingRules": [
+			{
+				"jsonPath": "/fhir/Organization/address/line",
+				"rule": "redactRule"
+			}
+		]
+	}
+}
+    

--- a/ipv-core/src/test/resources/config/pathNotLeaf.norule.config.json
+++ b/ipv-core/src/test/resources/config/pathNotLeaf.norule.config.json
@@ -1,0 +1,27 @@
+{
+    "defaultNoRuleResolution": false,
+	"rules": [
+		{
+			"name": "maintainRule",
+			"maskingProviders": [
+				{
+					"type": "MAINTAIN"
+				}
+			]
+		}
+	],
+	"json": {
+		"schemaType": "FHIR",
+		"messageTypeKey": "resourceType",
+		"messageTypes": [
+			"Organization"
+		],
+		"maskingRules": [
+			{
+				"jsonPath": "/fhir/Organization/address/line",
+				"rule": "maintainRule"
+			}
+		]
+	}
+}
+    

--- a/ipv-core/src/test/resources/data/defNoRuleRes.type-listed-no-rules.json
+++ b/ipv-core/src/test/resources/data/defNoRuleRes.type-listed-no-rules.json
@@ -1,0 +1,17 @@
+{
+	"resourceType": "Patient",
+	"id": "14",
+	"address": [
+		{
+			"line": [
+				"101 University Dr",
+				"102 University Dr",
+				"101 University Dr",
+				"103 University Dr",
+				{"a":1,"b":2},
+				["box1","box2"],
+				[{"c":3,"d":4}]
+			]
+		}
+	]
+}

--- a/ipv-core/src/test/resources/data/defNoRuleRes.type-not-listed.json
+++ b/ipv-core/src/test/resources/data/defNoRuleRes.type-not-listed.json
@@ -1,0 +1,17 @@
+{
+	"resourceType": "Device",
+	"id": "24",
+	"address": [
+		{
+			"line": [
+				"101 University Dr",
+				"102 University Dr",
+				"101 University Dr",
+				"103 University Dr",
+				{"a":1,"b":2},
+				["box1","box2"],
+				[{"c":3,"d":4}]
+			]
+		}
+	]
+}

--- a/ipv-core/src/test/resources/data/defNoRuleRes.type-not-present.json
+++ b/ipv-core/src/test/resources/data/defNoRuleRes.type-not-present.json
@@ -1,0 +1,17 @@
+{
+	"resources": "Unknown",
+	"id": "34",
+	"address": [
+		{
+			"line": [
+				"101 University Dr",
+				"102 University Dr",
+				"101 University Dr",
+				"103 University Dr",
+				{"a":1,"b":2},
+				["box1","box2"],
+				[{"c":3,"d":4}]
+			]
+		}
+	]
+}

--- a/ipv-core/src/test/resources/data/identical-array.json
+++ b/ipv-core/src/test/resources/data/identical-array.json
@@ -1,0 +1,12 @@
+{
+	"address": [
+		{
+			"line": [
+				"3300 University Dr, Suite 19",
+				"3300 University Dr, Suite 19",
+				"3300 University Dr, Suite 19",
+				"3300 University Dr, Suite 19"
+			]
+		}
+	]
+}

--- a/ipv-core/src/test/resources/data/pathNotLeaf.array.json
+++ b/ipv-core/src/test/resources/data/pathNotLeaf.array.json
@@ -1,0 +1,14 @@
+{
+	"resourceType": "Organization",
+	"id": "2",
+	"address": [
+		{
+			"line": [
+				"101 University Dr",
+				"102 University Dr",
+				"101 University Dr",
+				"103 University Dr"
+			]
+		}
+	]
+}

--- a/ipv-core/src/test/resources/data/pathNotLeaf.leaf.json
+++ b/ipv-core/src/test/resources/data/pathNotLeaf.leaf.json
@@ -1,0 +1,9 @@
+{
+	"resourceType": "Organization",
+	"id": "1",
+	"address": [
+		{
+			"line": "101 University Dr"
+		}
+	]
+}

--- a/ipv-core/src/test/resources/data/pathNotLeaf.mixed-array.json
+++ b/ipv-core/src/test/resources/data/pathNotLeaf.mixed-array.json
@@ -1,0 +1,18 @@
+{
+	"resourceType": "Organization",
+	"id": "4",
+	"address": [
+		{
+			"line": [
+				"101 University Dr",
+				"102 University Dr",
+				"101 University Dr",
+				"103 University Dr",
+				null,
+				{"a":1,"b":2},
+				["box1","box2"],
+				[{"c":3,"d":4,"e":null}]
+			]
+		}
+	]
+}

--- a/ipv-core/src/test/resources/data/pathNotLeaf.nested-array.json
+++ b/ipv-core/src/test/resources/data/pathNotLeaf.nested-array.json
@@ -1,0 +1,9 @@
+{
+	"resourceType": "Organization",
+	"id": "5",
+	"address": [
+		{
+			"line": [["one","two","three"],[1,2,3]]
+		}
+	]
+}

--- a/ipv-core/src/test/resources/data/pathNotLeaf.object.json
+++ b/ipv-core/src/test/resources/data/pathNotLeaf.object.json
@@ -1,0 +1,12 @@
+{
+	"resourceType": "Organization",
+	"id": "3",
+	"address": [
+		{
+			"line": {
+				"city": "Hope",
+				"state": "ND"
+			}
+		}
+	]	
+}

--- a/ipv-core/src/test/resources/result/defNoRuleRes.result.type-listed-no-rules.json
+++ b/ipv-core/src/test/resources/result/defNoRuleRes.result.type-listed-no-rules.json
@@ -1,0 +1,1 @@
+{"resourceType":null,"id":null,"address":[{"line":[null,null,null,null,{"a":null,"b":null},[null,null],[{"c":null,"d":null}]]}]}

--- a/ipv-core/src/test/resources/result/defNoRuleRes.result.type-not-listed.json
+++ b/ipv-core/src/test/resources/result/defNoRuleRes.result.type-not-listed.json
@@ -1,0 +1,1 @@
+{"resourceType":"Device","id":"24","address":[{"line":["101 University Dr","102 University Dr","101 University Dr","103 University Dr",{"a":1,"b":2},["box1","box2"],[{"c":3,"d":4}]]}]}

--- a/ipv-core/src/test/resources/result/defNoRuleRes.result.type-not-present.json
+++ b/ipv-core/src/test/resources/result/defNoRuleRes.result.type-not-present.json
@@ -1,0 +1,1 @@
+{"resources":"Unknown","id":"34","address":[{"line":["101 University Dr","102 University Dr","101 University Dr","103 University Dr",{"a":1,"b":2},["box1","box2"],[{"c":3,"d":4}]]}]}

--- a/ipv-core/src/test/resources/result/pathNotLeaf.result.array.json
+++ b/ipv-core/src/test/resources/result/pathNotLeaf.result.array.json
@@ -1,0 +1,1 @@
+{"resourceType":"Organization","id":"2","address":[{"line":["XXXXXXXXXXXXXXXXX","XXXXXXXXXXXXXXXXX","XXXXXXXXXXXXXXXXX","XXXXXXXXXXXXXXXXX"]}]}

--- a/ipv-core/src/test/resources/result/pathNotLeaf.result.leaf.json
+++ b/ipv-core/src/test/resources/result/pathNotLeaf.result.leaf.json
@@ -1,0 +1,1 @@
+{"resourceType":"Organization","id":"1","address":[{"line":"XXXXXXXXXXXXXXXXX"}]}

--- a/ipv-core/src/test/resources/result/pathNotLeaf.result.mixed-array.json
+++ b/ipv-core/src/test/resources/result/pathNotLeaf.result.mixed-array.json
@@ -1,0 +1,1 @@
+{"resourceType":"Organization","id":"4","address":[{"line":["XXXXXXXXXXXXXXXXX","XXXXXXXXXXXXXXXXX","XXXXXXXXXXXXXXXXX","XXXXXXXXXXXXXXXXX",null,{"a":1,"b":2},["XXXX","XXXX"],[{"c":3,"d":4,"e":null}]]}]}

--- a/ipv-core/src/test/resources/result/pathNotLeaf.result.nested-array.json
+++ b/ipv-core/src/test/resources/result/pathNotLeaf.result.nested-array.json
@@ -1,0 +1,1 @@
+{"resourceType":"Organization","id":"5","address":[{"line":[["XXX","XXX","XXXXX"],["X","X","X"]]}]}

--- a/ipv-core/src/test/resources/result/pathNotLeaf.result.norule.array.json
+++ b/ipv-core/src/test/resources/result/pathNotLeaf.result.norule.array.json
@@ -1,0 +1,1 @@
+{"resourceType":null,"id":null,"address":[{"line":["101 University Dr","102 University Dr","101 University Dr","103 University Dr"]}]}

--- a/ipv-core/src/test/resources/result/pathNotLeaf.result.norule.leaf.json
+++ b/ipv-core/src/test/resources/result/pathNotLeaf.result.norule.leaf.json
@@ -1,0 +1,1 @@
+{"resourceType":null,"id":null,"address":[{"line":"101 University Dr"}]}

--- a/ipv-core/src/test/resources/result/pathNotLeaf.result.norule.mixed-array.json
+++ b/ipv-core/src/test/resources/result/pathNotLeaf.result.norule.mixed-array.json
@@ -1,0 +1,1 @@
+{"resourceType":null,"id":null,"address":[{"line":["101 University Dr","102 University Dr","101 University Dr","103 University Dr",null,{"a":null,"b":null},["box1","box2"],[{"c":null,"d":null,"e":null}]]}]}

--- a/ipv-core/src/test/resources/result/pathNotLeaf.result.norule.nested-array.json
+++ b/ipv-core/src/test/resources/result/pathNotLeaf.result.norule.nested-array.json
@@ -1,0 +1,1 @@
+{"resourceType":null,"id":null,"address":[{"line":[["one","two","three"],[1,2,3]]}]}

--- a/ipv-core/src/test/resources/result/pathNotLeaf.result.norule.object.json
+++ b/ipv-core/src/test/resources/result/pathNotLeaf.result.norule.object.json
@@ -1,0 +1,1 @@
+{"resourceType":null,"id":null,"address":[{"line":{"city":null,"state":null}}]}

--- a/ipv-core/src/test/resources/result/pathNotLeaf.result.object.json
+++ b/ipv-core/src/test/resources/result/pathNotLeaf.result.object.json
@@ -1,0 +1,1 @@
+{"resourceType":"Organization","id":"3","address":[{"line":{"city":"Hope","state":"ND"}}]}

--- a/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/DeidMaskingConfig.java
+++ b/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/DeidMaskingConfig.java
@@ -42,7 +42,7 @@ public class DeidMaskingConfig implements Serializable {
   @JsonAlias({"certificateID"})
   private String certificateId;
 
-  private boolean defaultNoRuleResolution;
+  private boolean defaultNoRuleResolution = true;
 
   public DeidMaskingConfig() {
     // nothing required here


### PR DESCRIPTION
Activated "no rule resolution" support, which removes all leaf nodes from each input document of one of the configured resource types that have not been addressed by a specific masking rule.

Renamed some methods to better reflect the role they currently play in the masking process.