### PR TITLE
Create De-Identification Service Chart

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -1,0 +1,43 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing (ct)
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Get changed charts (ct list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs de-identification-app --target-branch master)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Lint charts (ct lint)
+        run: ct lint --chart-dirs de-identification-app --target-branch master --validate-maintainers=false --debug
+
+      - name: Create 'kind' cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (ct install)
+        run: ct install

--- a/de-identification-app/chart/Chart.yaml
+++ b/de-identification-app/chart/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: deid
+description: A Helm Chart to deploy the Alvearie De-Identification service.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.0.1
+
+keywords:
+  - ibm
+  - health records
+  - clinical data
+  - alvearie
+  - deid
+
+home: https://github.com/Alvearie/de-identification
+
+maintainers:
+  - name: Susan Crowell
+    email: sfc@us.ibm.com

--- a/de-identification-app/chart/README.md
+++ b/de-identification-app/chart/README.md
@@ -1,0 +1,57 @@
+# De-Identification Service Helm Chart
+
+## Introduction
+
+This [Helm](https://github.com/kubernetes/helm) chart installs an instance of the [Alvearie De-Identification](https://github.com/Alvearie/de-identification) service in a Kubernetes cluster.
+
+## Pre-Requisites
+
+- Kubernetes cluster 1.10+
+- Helm 3.0.0+
+
+## Installation
+
+### Checkout the Code
+
+Git clone this repository and `cd` into this directory.
+
+```bash
+git clone https://github.com/Alvearie/health-patterns.git
+cd de-identificaiton-app/chart
+```
+
+### Install the Chart
+
+Install the helm chart with a desired release name, such as `deid` and follow the resulting instructions:
+
+```bash
+helm install deid .
+```
+
+### Using the Chart
+
+Access your FHIR server at: `http://<external-ip>:8080/api/v1/health`
+
+## Uninstallation
+
+To uninstall/delete the `deid` deployment:
+
+```bash
+helm delete deid
+```
+
+## Configuration
+
+Each requirement is configured with the options provided by that Chart.
+Please consult the relevant charts for their configuration options.
+
+See `values.yaml`.
+
+## Contributing
+
+Feel free to contribute by making a [pull request](https://github.com/Alvearie/de-identification/pull/new/master).
+
+Please review the [Contributing Guide](https://github.com/Alvearie/de-identification/blob/master/docs/contributing.md) for information on how to get started contributing to the project.
+
+## License
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 

--- a/de-identification-app/chart/templates/NOTES.txt
+++ b/de-identification-app/chart/templates/NOTES.txt
@@ -1,0 +1,35 @@
+The De-Identification Services can be accessed from within your cluster at the following location:
+
+  {{ include "deid.fullname" .}}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+ 
+To connect to your NiFi Registry from outside the cluster, follow the instructions below:
+ 
+Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "deid.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")  
+  echo NiFi Registry: http://$NODE_IP:$NODE_PORT/api/v1/deidentification
+  
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+It may take a few minutes for the LoadBalancer IP to be available.
+
+You can watch the status by running the following command and wait unti the external IP address appears: 
+
+  kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "deid.fullname" . }}
+
+Once the external IP has been assigned run the following:
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "deid.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}') 
+  echo NiFi Registry: http://$SERVICE_IP:{{ .Values.service.Port }}/api/v1/deidentification
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "deid.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo De-Identification Service Health endpoint: http://127.0.0.1:{{ .Values.service.port }}/api/v1/health
+  echo De-Identification Service DeId endpoint: http://127.0.0.1:{{ .Values.service.port }}/api/v1/deidentification
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.port }}:{{ .Values.service.port }}
+  
+
+{{- end }}

--- a/de-identification-app/chart/templates/_helpers.tpl
+++ b/de-identification-app/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "deid.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "deid.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "deid.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "deid.labels" -}}
+helm.sh/chart: {{ include "deid.chart" . }}
+{{ include "deid.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "deid.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "deid.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "deid.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "deid.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/de-identification-app/chart/templates/deployment.yaml
+++ b/de-identification-app/chart/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "deid.fullname" . }}
+  labels:
+    {{- include "deid.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "deid.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "deid.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+{{- range $key, $value := .Values.initContainers }}
+        - name: {{ $key }}
+{{ toYaml $value | indent 10 }}
+{{- end }}        
+      containers:
+        - name: service
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/de-identification-app/chart/templates/service.yaml
+++ b/de-identification-app/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "deid.fullname" . }}
+  labels:
+    {{- include "deid.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: deid-server-http
+  selector:
+    {{- include "deid.selectorLabels" . | nindent 4 }}

--- a/de-identification-app/chart/templates/tests/test-deid-api.yaml
+++ b/de-identification-app/chart/templates/tests/test-deid-api.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "deid.fullname" . }}-test"
+  labels:
+    {{- include "deid.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: test
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "deid.fullname" . }}:{{ .Values.service.port }}/api/v1/health']
+  restartPolicy: Never

--- a/de-identification-app/chart/values.yaml
+++ b/de-identification-app/chart/values.yaml
@@ -1,0 +1,44 @@
+# Declare variables to be passed into your templates.
+replicaCount: 1
+
+image:
+  repository: alvearie/deid
+  pullPolicy: IfNotPresent
+  tag: 0.0.1
+service:
+  type: ClusterIP
+  port: 8080
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This commit implements the Helm Chart for the Alvearie De-Idenfitication service.
The Helm Chart allows deploying the corresponding Docker, i.e. `alvearie/deid`,
to a Kubernetes cluster.

The commit additionally includes a new Github action to lint and install the chart
with every delivery that changes the chart.