### PR TITLE
Updates to privacy provider configuration and parameter processing

### DIFF
--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/BasicMaskingProviderFactory.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/BasicMaskingProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -41,6 +41,7 @@ import com.ibm.whc.deid.shared.pojo.config.masking.MACAddressMaskingProviderConf
 import com.ibm.whc.deid.shared.pojo.config.masking.MaritalStatusMaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.config.masking.MaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.config.masking.NameMaskingProviderConfig;
+import com.ibm.whc.deid.shared.pojo.config.masking.NullMaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.config.masking.NumberVarianceMaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.config.masking.OccupationMaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.config.masking.PhoneMaskingProviderConfig;
@@ -64,7 +65,7 @@ import com.ibm.whc.deid.shared.pojo.masking.MaskingProviderTypes;
  *
  */
 public class BasicMaskingProviderFactory implements Serializable, MaskingProviderFactory {
-  /** */
+  
   private static final long serialVersionUID = -7454645556196383954L;
 
   private final HashMap<String, HashMap<MaskingProviderConfig, MaskingProvider>> maskingProvidersCache;
@@ -220,7 +221,7 @@ public class BasicMaskingProviderFactory implements Serializable, MaskingProvide
         provider = new NameMaskingProvider((NameMaskingProviderConfig) config, tenantId);
         break;
       case NULL:
-        provider = new NullMaskingProvider();
+        provider = new NullMaskingProvider((NullMaskingProviderConfig) config);
         break;
       case NUMBERVARIANCE:
         provider = new NumberVarianceMaskingProvider((NumberVarianceMaskingProviderConfig) config);

--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProvider.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -103,21 +103,17 @@ public class DateTimeMaskingProvider extends AbstractMaskingProvider {
   private final String dateYearDeleteComparedValue;
   private final int unspecifiedValueHandling;
   private final String unspecifiedValueReturnMessage;
-
-  private DateTimeFormatter fixedDateFormat = null;
+  private final DateTimeFormatter fixedDateFormat;
 
   public DateTimeMaskingProvider(DateTimeMaskingProviderConfig configuration) {
     String fixedDateFormatString = configuration.getFormatFixed();
-
-    if (fixedDateFormatString != null) {
-      fixedDateFormat = new DateTimeFormatterBuilder().appendPattern(fixedDateFormatString)
-          .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
-          .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
-          .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter();
-
-    } else {
-      this.fixedDateFormat = null;
-    }
+    this.fixedDateFormat =
+        (fixedDateFormatString != null && !fixedDateFormatString.trim().isEmpty())
+            ? new DateTimeFormatterBuilder().appendPattern(fixedDateFormatString)
+                .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+                .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter()
+            : null;
 
     this.shiftDate = configuration.isMaskShiftDate();
     this.shiftSeconds = configuration.getMaskShiftSeconds();
@@ -201,17 +197,15 @@ public class DateTimeMaskingProvider extends AbstractMaskingProvider {
     this.dateYearDeleteComparedValue = compareDateValue;
 
     DateTimeMaskingProviderConfig configuration = new DateTimeMaskingProviderConfig();
+    
     String fixedDateFormatString = configuration.getFormatFixed();
-
-    if (fixedDateFormatString != null) {
-      fixedDateFormat = new DateTimeFormatterBuilder().appendPattern(fixedDateFormatString)
-          .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
-          .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
-          .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter();
-
-    } else {
-      this.fixedDateFormat = null;
-    }
+    this.fixedDateFormat =
+        (fixedDateFormatString != null && !fixedDateFormatString.trim().isEmpty())
+            ? new DateTimeFormatterBuilder().appendPattern(fixedDateFormatString)
+                .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+                .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter()
+            : null;
 
     this.shiftDate = configuration.isMaskShiftDate();
     this.shiftSeconds = configuration.getMaskShiftSeconds();

--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/NameMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/NameMaskingProvider.java
@@ -1,13 +1,13 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.ibm.whc.deid.providers.masking;
 
 import java.security.SecureRandom;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import com.ibm.whc.deid.models.FirstName;
 import com.ibm.whc.deid.models.LastName;
 import com.ibm.whc.deid.shared.pojo.config.masking.NameMaskingProviderConfig;
@@ -18,7 +18,7 @@ import com.ibm.whc.deid.util.NamesManager;
  *
  */
 public class NameMaskingProvider extends AbstractMaskingProvider {
-  /** */
+  
   private static final long serialVersionUID = 3798105506081000286L;
 
   protected NamesManager.NameManager names;
@@ -41,7 +41,7 @@ public class NameMaskingProvider extends AbstractMaskingProvider {
     this.consistent = configuration.isTokenConsistence();
     this.genderPreserve = configuration.isMaskGenderPreserve();
     this.getPseudorandom = configuration.isMaskPseudorandom();
-    this.tokenCache = this.consistent ? new HashMap<String, String>() : null;
+    this.tokenCache = this.consistent ? new ConcurrentHashMap<String, String>() : null;
     this.unspecifiedValueHandling = configuration.getUnspecifiedValueHandling();
     this.unspecifiedValueReturnMessage = configuration.getUnspecifiedValueReturnMessage();
   }
@@ -119,7 +119,9 @@ public class NameMaskingProvider extends AbstractMaskingProvider {
         }
 
         if (consistent)
-          tokenCache.put(token, maskedToken);
+          if (maskedToken != null) {
+            tokenCache.put(token, maskedToken);
+          }
       }
 
       builder.append(maskedToken);

--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/PseudonymMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/PseudonymMaskingProvider.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,7 +17,7 @@ import com.ibm.whc.deid.util.ReversePatternManager;
  *
  */
 public class PseudonymMaskingProvider extends AbstractMaskingProvider {
-  /** */
+  
   private static final long serialVersionUID = -185505347822379112L;
 
   private final boolean generateViaOptions;
@@ -87,7 +87,7 @@ public class PseudonymMaskingProvider extends AbstractMaskingProvider {
     if (this.generateViaPattern) {
 
       ReversePatternGenerator patternGenerator;
-      if (this.pattern != null) {
+      if (this.pattern != null && !this.pattern.trim().isEmpty()) {
         patternGenerator = ReversePatternManager.getInstance().getPatternByPattern(this.pattern,
             this.patternLanguageCode);
       } else {

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/CountyMaskingProviderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/CountyMaskingProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,6 +14,7 @@ import org.junit.Test;
 import com.ibm.whc.deid.providers.identifiers.CountyIdentifier;
 import com.ibm.whc.deid.providers.identifiers.Identifier;
 import com.ibm.whc.deid.shared.pojo.config.masking.CountyMaskingProviderConfig;
+import com.ibm.whc.deid.shared.pojo.masking.MaskingProviderType;
 
 public class CountyMaskingProviderTest extends TestLogSetUp implements MaskingProviderTest {
   /*
@@ -22,6 +23,7 @@ public class CountyMaskingProviderTest extends TestLogSetUp implements MaskingPr
   @Test
   public void testPseudorandom() throws Exception {
     CountyMaskingProviderConfig configuration = new CountyMaskingProviderConfig();
+    assertEquals(MaskingProviderType.COUNTY, configuration.getType());
     configuration.setMaskPseudorandom(true);
 
     MaskingProvider maskingProvider = new CountyMaskingProvider(configuration, tenantId);
@@ -43,6 +45,7 @@ public class CountyMaskingProviderTest extends TestLogSetUp implements MaskingPr
     // county.mask.pseudorandom by default is off
     Identifier identifier = new CountyIdentifier();
     CountyMaskingProviderConfig configuration = new CountyMaskingProviderConfig();
+    assertEquals(MaskingProviderType.COUNTY, configuration.getType());
 
     MaskingProvider maskingProvider = new CountyMaskingProvider(configuration, tenantId);
 

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProviderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProviderTest.java
@@ -103,6 +103,7 @@ public class DateTimeMaskingProviderTest extends TestLogSetUp {
   public void testMaskShiftDateNegative() throws Exception {
 
     DateTimeMaskingProviderConfig config = new DateTimeMaskingProviderConfig();
+    config.setFormatFixed("  \t\n  ");  // whitespace, so ignored
     config.setMaskShiftDate(true);
     config.setMaskShiftSeconds(-120);
     DateTimeMaskingProvider maskingProvider = new DateTimeMaskingProvider(config);
@@ -110,8 +111,6 @@ public class DateTimeMaskingProviderTest extends TestLogSetUp {
     // different values
     String originalDateTime = "08-12-1981 00:04:00";
     String maskedDateTime = maskingProvider.mask(originalDateTime);
-    assertFalse(originalDateTime.equals(maskedDateTime));
-
     assertEquals("08-12-1981 00:02:00", maskedDateTime);
   }
 

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/PseudonymMaskingProviderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/PseudonymMaskingProviderTest.java
@@ -250,13 +250,19 @@ public class PseudonymMaskingProviderTest extends TestLogSetUp {
 
     PseudonymMaskingProviderConfig configuration = new PseudonymMaskingProviderConfig();
     setAllPseudonymMaskingToFalse(configuration);
-    configuration.setGenerateViaPatternEnabled(true);
+    configuration.setGenerateViaPatternEnabled(true);    
     configuration.setGenerateViaPatternPatternName("DOES_NOT_EXIST");
     configuration.setGenerateViaPatternLanguageCode("EN");
     PseudonymMaskingProvider maskingProvider = new PseudonymMaskingProvider(configuration);
 
     String maskedValue = maskingProvider.mask(originalValue);
 
+    assertTrue("".equals(maskedValue));
+    
+    // whitespace (missing) pattern instead of null
+    configuration.setGenerateViaPatternPattern("  ");
+    maskingProvider = new PseudonymMaskingProvider(configuration);
+    maskedValue = maskingProvider.mask(originalValue);
     assertTrue("".equals(maskedValue));
   }
 

--- a/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/masking/CountyMaskingProviderConfig.java
+++ b/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/masking/CountyMaskingProviderConfig.java
@@ -18,7 +18,7 @@ public class CountyMaskingProviderConfig extends MaskingProviderConfig {
   boolean maskPseudorandom = false;
 
   public CountyMaskingProviderConfig() {
-    type = MaskingProviderType.CITY;
+    type = MaskingProviderType.COUNTY;
   }
 
   public boolean isMaskPseudorandom() {


### PR DESCRIPTION
Correct deserialization issue with COUNTY privacy provider.
Equate empty/whitespace string to null for the fixed format parameter on the DATETIME privacy provider. Allows default formats to be used.
Equate empty/whitespace string to null for the pattern name parameter on the PSEUDONYM privacy provider.
Allow parameters to be passed to NULL privacy provider.
Concurrency protection in NAME privacy provider.
