### PR TITLE
Generic masking of URL query parameters

### DIFF
--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/MaskingProviderFactory.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/MaskingProviderFactory.java
@@ -14,11 +14,14 @@ public interface MaskingProviderFactory {
   /**
    * Get a masking provider based on type.
    * 
-   * @param providerType
-   * @param deidMaskingConfig
-   * @param config
-   * @param tenantId
-   * @return
+   * @param providerType the type of provider to create
+   * @param deidMaskingConfig the complete masking provider configuration
+   * @param config the configuration for the provider to create
+   * @param tenantId the current tenant
+   * 
+   * @return the requested masking provider object
+   * 
+   * @throws NullPointerException if providerType or config are <i>null</i>
    */
   public MaskingProvider getProviderFromType(MaskingProviderTypes providerType,
       DeidMaskingConfig deidMaskingConfig, MaskingProviderConfig config, String tenantId);

--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/URLMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/URLMaskingProvider.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,23 +8,15 @@ package com.ibm.whc.deid.providers.masking;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.SecureRandom;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.commons.lang3.StringUtils;
-
-import com.ibm.whc.deid.providers.ProviderType;
-import com.ibm.whc.deid.providers.identifiers.Identifier;
-import com.ibm.whc.deid.providers.identifiers.IdentifierFactoryUtil;
 import com.ibm.whc.deid.shared.pojo.config.DeidMaskingConfig;
-import com.ibm.whc.deid.shared.pojo.config.masking.MaskingProviderConfig;
+import com.ibm.whc.deid.shared.pojo.config.masking.RedactMaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.config.masking.URLMaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.masking.MaskingProviderType;
 import com.ibm.whc.deid.util.RandomGenerators;
 
 public class URLMaskingProvider extends AbstractMaskingProvider {
-  /** */
+
   private static final long serialVersionUID = 5992875957296289762L;
 
   private final boolean maskUsernamePassword;
@@ -32,15 +24,12 @@ public class URLMaskingProvider extends AbstractMaskingProvider {
   private final boolean removeQuery;
   private final boolean maskQuery;
   private final int preserveDomains;
-  private final Map<ProviderType, MaskingProvider> providerMap =
-      new HashMap<>(ProviderType.values().length);
   private final MaskingProviderFactory maskingProviderFactory =
       MaskingProviderFactoryUtil.getMaskingProviderFactory();
   private final int unspecifiedValueHandling;
   private final String unspecifiedValueReturnMessage;
-
-  private String tenantId;
-  DeidMaskingConfig deidMaskingConfig;
+  private final String tenantId;
+  private final DeidMaskingConfig deidMaskingConfig;
 
 
   public URLMaskingProvider(URLMaskingProviderConfig configuration, String tenantId,
@@ -93,23 +82,16 @@ public class URLMaskingProvider extends AbstractMaskingProvider {
   }
 
   /**
-   * Gets masking provider.
+   * Gets the masking provider used to mask portions of the query string.
    *
    * @param type the type
    * @return the masking provider
    */
-  public synchronized MaskingProvider getMaskingProvider(ProviderType type) {
-    if (providerMap.containsKey(type)) {
-      return providerMap.get(type);
-    }
-
-    MaskingProviderType maskignProviderType = MaskingProviderType.valueOf(type.getName());
-    MaskingProvider maskingProvider =
-        maskingProviderFactory.getProviderFromType(maskignProviderType, deidMaskingConfig,
-            MaskingProviderConfig.getDefaultMaskingProviderConfig(maskignProviderType), tenantId);
-    providerMap.put(type, maskingProvider);
-
-    return maskingProvider;
+  protected MaskingProvider getQueryPartMaskingProvider() {
+    RedactMaskingProviderConfig providerConfig = new RedactMaskingProviderConfig();
+    providerConfig.setPreserveLength(false);
+    return maskingProviderFactory.getProviderFromType(MaskingProviderType.REDACT, deidMaskingConfig,
+        providerConfig, tenantId);
   }
 
   private String maskQuery(String query) {
@@ -117,11 +99,10 @@ public class URLMaskingProvider extends AbstractMaskingProvider {
       return query;
     }
 
-    Collection<Identifier> identifiers =
-				IdentifierFactoryUtil.getIdentifierFactory().getAvailableIdentifiers(tenantId);
-
     String[] tokens = query.split("&");
     String[] maskedTokens = new String[tokens.length];
+
+    MaskingProvider maskingProvider = null;
 
     for (int i = 0; i < tokens.length; i++) {
       String token = tokens[i];
@@ -135,13 +116,11 @@ public class URLMaskingProvider extends AbstractMaskingProvider {
         continue;
       }
 
-      for (Identifier identifier : identifiers) {
-        if (identifier.isOfThisType(parts[1])) {
-          MaskingProvider maskingProvider = getMaskingProvider(identifier.getType());
-          parts[1] = maskingProvider.mask(parts[1]);
-          break;
-        }
+      if (maskingProvider == null) {
+        maskingProvider = getQueryPartMaskingProvider();
       }
+
+      parts[1] = maskingProvider.mask(parts[1]);
 
       maskedTokens[i] = parts[0] + "=" + parts[1];
     }
@@ -211,11 +190,7 @@ public class URLMaskingProvider extends AbstractMaskingProvider {
     } catch (MalformedURLException e) {
       // For this provider, we do not return random URL
       debugFaultyInput("url");
-      if (unspecifiedValueHandling == 3) {
-        return unspecifiedValueReturnMessage;
-      } else {
-        return null;
-      }
+      return unspecifiedValueHandling == 3 ? unspecifiedValueReturnMessage : null;
     }
 
     return maskURL(url);

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/URLMaskingProviderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/URLMaskingProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -286,12 +286,12 @@ public class URLMaskingProviderTest extends TestLogSetUp {
     configuration.setMaskMaskQuery(true);
     MaskingProvider urlMaskingProvider =
         new URLMaskingProvider(configuration, tenantId, deidMaskingConfig);
-    String url = "http://www.nba.com?q=John&q2=Mary&q3=foobar&q4=";
+    String url = "http://www.nba.com?q=John&q2=Mary&q3=foobar&q4=&q5&q6=33&q7=true&state=Montana";
     String maskedResult = urlMaskingProvider.mask(url);
     URL maskedURL = new URL(maskedResult);
     String maskedFile = maskedURL.getFile();
     System.out.println(maskedResult);
-    assertFalse(maskedFile.equals("?q=John"));
+    assertEquals("?q=X&q2=X&q3=X&q4=&q5&q6=X&q7=X&state=X", maskedFile);
   }
 
   @Test


### PR DESCRIPTION
When masking query parameter values with the URL privacy provider, replace each value with a single uppercase X.