### PR TITLE
Masking configuration validation updates

### DIFF
--- a/de-identification-app/src/test/java/com/ibm/whc/deid/app/endpoint/datamasking/DataMaskingControllerErrorPathTest.java
+++ b/de-identification-app/src/test/java/com/ibm/whc/deid/app/endpoint/datamasking/DataMaskingControllerErrorPathTest.java
@@ -44,7 +44,9 @@ import com.ibm.whc.deid.shared.pojo.config.json.JsonMaskingRule;
 import com.ibm.whc.deid.shared.pojo.config.masking.AddressMaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.config.masking.CityMaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.config.masking.ContinentMaskingProviderConfig;
+import com.ibm.whc.deid.shared.pojo.config.masking.GenderMaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.config.masking.HashMaskingProviderConfig;
+import com.ibm.whc.deid.shared.pojo.config.masking.MaskingProviderConfig;
 import com.ibm.whc.deid.shared.pojo.masking.DataMaskingModel;
 
 @RunWith(SpringRunner.class)
@@ -87,15 +89,15 @@ public class DataMaskingControllerErrorPathTest {
     String emptyObject = "{}";
     log.info(noContent);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(noContent))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(noContent))
         .andDo(print()).andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print())
         .andExpect(content().string(startsWith("Required request body is missing")));
 
     log.info(emptyObject);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(emptyObject))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(emptyObject))
         .andDo(print()).andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print())
         .andExpect(content().string("no configuration data"));
   }
@@ -113,8 +115,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print())
         .andExpect(content().string("Invalid input error data[0]"));
   }
@@ -129,8 +131,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print())
         .andExpect(content().string("Invalid input error data"));
 
@@ -140,8 +142,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print())
         .andExpect(content().string("Invalid input error data"));
   }
@@ -159,8 +161,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print())
         .andExpect(content().string("no configuration data"));
   }
@@ -177,8 +179,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print())
         .andExpect(content().string(startsWith("Invalid input error schemaType")));
   }
@@ -195,8 +197,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest()).andDo(MockMvcResultHandlers.print())
         .andExpect(content().string(startsWith("JSON parse error")));
   }
@@ -216,8 +218,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: the value of the `json` property is missing")));
@@ -238,8 +240,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andExpect(status().isBadRequest()).andDo(print())
         .andExpect(content().string(containsString("`json.schemaType` property is missing")));
   }
@@ -259,8 +261,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: `json.messageTypes` must be provided when `json.messageTypeKey` is provided")));
@@ -281,8 +283,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: `json.messageTypes` must be provided when `json.messageTypeKey` is provided")));
@@ -303,8 +305,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: value at offset 0 in `json.messageTypes` is missing")));
@@ -325,8 +327,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: value at offset 1 in `json.messageTypes` is missing")));
@@ -347,8 +349,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: value at offset 2 in `json.messageTypes` is missing")));
@@ -369,8 +371,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: `rule` property is missing from the rule assignment at offset 0 in `json.maskingRules`")));
@@ -391,8 +393,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: `rule` property is missing from the rule assignment at offset 1 in `json.maskingRules`")));
@@ -413,8 +415,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: `jsonPath` property in the rule assignment at offset 2 in `json.maskingRules` must start with `/`")));
@@ -462,8 +464,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "The JSON masking rule does not refer to a valid rule: no_1. There are 4 invalid rules.")));
@@ -485,8 +487,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: the rule at offset " + count + " in `rules` is null")));
@@ -508,8 +510,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: the `name` property is missing from the rule at offset 1 in `rules`")));
@@ -531,8 +533,8 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
             "invalid masking configuration: the `name` property is missing from the rule at offset 2 in `rules`")));
@@ -547,7 +549,6 @@ public class DataMaskingControllerErrorPathTest {
     DeidMaskingConfig config = objectMapper.readValue(TEST_CONFIG, DeidMaskingConfig.class);
 
     String ruleName = config.getRules().get(0).getName();
-    int count = config.getRules().size();
     config.getRules().add(new Rule(ruleName, Arrays.asList(new HashMaskingProviderConfig())));
 
     DataMaskingModel dataMaskingModel = new DataMaskingModel(
@@ -559,9 +560,9 @@ public class DataMaskingControllerErrorPathTest {
         .perform(post(basePath + "/deidentification")
             .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
         .andDo(print()).andExpect(status().isBadRequest())
-        .andExpect(content().string(containsString(
-            "invalid masking configuration: the value of the `name` property in the rule at offset "
-                + count + " in `rules` has already been used by another rule")));
+        .andExpect(content().string(containsString("invalid masking configuration: the value `"
+            + ruleName
+            + "` is used for the `name` property on multiple rules in the `rules` list - rule names must be unique")));
   }
 
   @Test
@@ -573,6 +574,7 @@ public class DataMaskingControllerErrorPathTest {
     DeidMaskingConfig config = objectMapper.readValue(TEST_CONFIG, DeidMaskingConfig.class);
 
     config.getRules().get(2).setMaskingProviders(null);
+    String ruleName = config.getRules().get(2).getName();
 
     DataMaskingModel dataMaskingModel = new DataMaskingModel(
         objectMapper.writeValueAsString(config), dataList, ConfigSchemaType.FHIR);
@@ -584,7 +586,8 @@ public class DataMaskingControllerErrorPathTest {
             .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
-            "invalid masking configuration: the `maskingProviders` property is missing from the rule at offset 2 in `rules`")));
+            "invalid masking configuration: the `maskingProviders` property is missing from the rule with `name` value `"
+                + ruleName + "` in `rules`")));
   }
 
   @Test
@@ -596,6 +599,7 @@ public class DataMaskingControllerErrorPathTest {
     DeidMaskingConfig config = objectMapper.readValue(TEST_CONFIG, DeidMaskingConfig.class);
 
     config.getRules().get(2).getMaskingProviders().add(null);
+    String ruleName = config.getRules().get(2).getName();
 
     DataMaskingModel dataMaskingModel = new DataMaskingModel(
         objectMapper.writeValueAsString(config), dataList, ConfigSchemaType.FHIR);
@@ -607,7 +611,24 @@ public class DataMaskingControllerErrorPathTest {
             .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
-            "invalid masking configuration: the masking provider at offset 1 in `maskingProviders` for the rule at offset 2 in `rules` is null")));
+            "invalid masking configuration: the second masking provider in `maskingProviders` for the rule with `name` value `"
+                + ruleName + "` in `rules` is null")));
+
+    config.getRules().get(2).getMaskingProviders().remove(1);
+    config.getRules().get(2).getMaskingProviders().add(0, null);
+
+    dataMaskingModel = new DataMaskingModel(objectMapper.writeValueAsString(config), dataList,
+        ConfigSchemaType.FHIR);
+    request = objectMapper.writeValueAsString(dataMaskingModel);
+
+    log.info(request);
+    this.mockMvc
+        .perform(post(basePath + "/deidentification")
+            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .andDo(print()).andExpect(status().isBadRequest())
+        .andExpect(content().string(containsString(
+            "invalid masking configuration: the first masking provider in `maskingProviders` for the rule with `name` value `"
+                + ruleName + "` in `rules` is null")));
   }
 
   @Test
@@ -618,6 +639,7 @@ public class DataMaskingControllerErrorPathTest {
     ObjectMapper objectMapper = ObjectMapperFactory.getObjectMapper();
     DeidMaskingConfig config = objectMapper.readValue(TEST_CONFIG, DeidMaskingConfig.class);
 
+    String ruleName = config.getRules().get(0).getName();
     config.getRules().get(0).getMaskingProviders().add(new HashMaskingProviderConfig());
     config.getRules().get(0).getMaskingProviders().add(new HashMaskingProviderConfig());
 
@@ -631,7 +653,8 @@ public class DataMaskingControllerErrorPathTest {
             .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
-            "invalid masking configuration: too many entries in `maskingProviders` for the rule at offset 0 in `rules` - the maximum allowed is 2")));
+            "invalid masking configuration: too many entries in `maskingProviders` for the rule with `name` value `"
+                + ruleName + "` in `rules` - the maximum allowed is 2")));
   }
 
   @Test
@@ -642,6 +665,7 @@ public class DataMaskingControllerErrorPathTest {
     ObjectMapper objectMapper = ObjectMapperFactory.getObjectMapper();
     DeidMaskingConfig config = objectMapper.readValue(TEST_CONFIG, DeidMaskingConfig.class);
     config.getRules().get(0).getMaskingProviders().add(0, new HashMaskingProviderConfig());
+    String ruleName = config.getRules().get(0).getName();
 
     DataMaskingModel dataMaskingModel = new DataMaskingModel(
         objectMapper.writeValueAsString(config), dataList, ConfigSchemaType.FHIR);
@@ -652,8 +676,9 @@ public class DataMaskingControllerErrorPathTest {
         .perform(post(basePath + "/deidentification")
             .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
         .andDo(print()).andExpect(status().isBadRequest())
-        .andExpect(content().string(containsString(
-            "invalid masking configuration: the rule at offset 0 in `rules` contains multiple masking providers, but the first masking provider is not a Category I provider")));
+        .andExpect(content().string(
+            containsString("invalid masking configuration: the rule with `name` value `" + ruleName
+                + "` in `rules` contains multiple masking providers, but the first masking provider is not a Category I provider")));
   }
 
   @Test
@@ -672,11 +697,11 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
-            "invalid masking configuration: the rule at offset 2 in `rules` contains multiple masking providers, but the second masking provider is not a Category II provider")));
+            "invalid masking configuration: the rule with `name` value `multiRuleX` in `rules` contains multiple masking providers, but the second masking provider is not a Category II provider")));
   }
 
   @Test
@@ -685,10 +710,12 @@ public class DataMaskingControllerErrorPathTest {
     dataList.add(TEST_DATA);
 
     ObjectMapper objectMapper = ObjectMapperFactory.getObjectMapper();
+    DeidMaskingConfig config = objectMapper.readValue(TEST_CONFIG, DeidMaskingConfig.class);
     AddressMaskingProviderConfig provider = new AddressMaskingProviderConfig();
     provider.setPostalCodeNearestK(-1);
-    DeidMaskingConfig config = objectMapper.readValue(TEST_CONFIG, DeidMaskingConfig.class);
-    config.getRules().add(1, new Rule("invalidRuleX", Arrays.asList(provider)));
+    ArrayList<MaskingProviderConfig> providers = new ArrayList<>();
+    providers.add(provider);
+    config.getRules().add(1, new Rule("invalidRuleX", providers));
 
     DataMaskingModel dataMaskingModel = new DataMaskingModel(
         objectMapper.writeValueAsString(config), dataList, ConfigSchemaType.FHIR);
@@ -696,11 +723,24 @@ public class DataMaskingControllerErrorPathTest {
 
     log.info(request);
     this.mockMvc
-        .perform(post(basePath + "/deidentification")
-            .contentType(MediaType.APPLICATION_JSON_VALUE).content(request))
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
         .andDo(print()).andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(
-            "invalid masking configuration: the masking provider at offset 0 in `maskingProviders` for the rule at offset 1 in `rules` is not valid: `postalCodeNearestK` must be greater than 0")));
-  }
+            "invalid masking configuration: the first masking provider in `maskingProviders` for the rule with `name` value `invalidRuleX` in `rules` is not valid: `postalCodeNearestK` must be greater than 0")));
 
+    providers.add(0, new GenderMaskingProviderConfig());
+
+    dataMaskingModel = new DataMaskingModel(objectMapper.writeValueAsString(config), dataList,
+        ConfigSchemaType.FHIR);
+    request = objectMapper.writeValueAsString(dataMaskingModel);
+
+    log.info(request);
+    this.mockMvc
+        .perform(post(basePath + "/deidentification").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request))
+        .andDo(print()).andExpect(status().isBadRequest())
+        .andExpect(content().string(containsString(
+            "invalid masking configuration: the second masking provider in `maskingProviders` for the rule with `name` value `invalidRuleX` in `rules` is not valid: `postalCodeNearestK` must be greater than 0")));
+  }
 }

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/fhir/FHIRMaskingProviderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/fhir/FHIRMaskingProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.IntStream;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -30,7 +29,6 @@ import com.ibm.whc.deid.shared.pojo.config.DeidMaskingConfig;
 import com.ibm.whc.deid.shared.pojo.config.json.JsonConfig;
 import com.ibm.whc.deid.shared.pojo.config.json.JsonMaskingRule;
 import com.ibm.whc.deid.shared.util.ConfigGenerator;
-import com.ibm.whc.deid.shared.util.MaskingConfigUtils;
 import scala.Tuple2;
 
 public class FHIRMaskingProviderTest {
@@ -41,7 +39,7 @@ public class FHIRMaskingProviderTest {
 
   private MaskingProviderFactory maskingProviderFactory =
       MaskingProviderFactoryUtil.getMaskingProviderFactory();
-  
+
   @Test
   public void testLoadRulesForResource() {
     DeidMaskingConfig config = new DeidMaskingConfig();
@@ -52,7 +50,7 @@ public class FHIRMaskingProviderTest {
 
     config.setJson(new JsonConfig());
     config.getJson().getMaskingRules().add(new JsonMaskingRule("/fhir/path/data", "rule1"));
-    assertEquals(1, config.getJson().getMaskingRules().size());    
+    assertEquals(1, config.getJson().getMaskingRules().size());
     list = FHIRMaskingProvider.loadRulesForResource("x", config, "/");
     assertNotNull(list);
     assertEquals(0, list.size());
@@ -61,7 +59,7 @@ public class FHIRMaskingProviderTest {
     assertEquals(1, list.size());
     assertEquals("/fhir/path/data", list.get(0).getKey());
     assertEquals("rule1", list.get(0).getShortRuleName());
-    
+
     config.setJson(null);
     assertNull(config.getJson());
     list = FHIRMaskingProvider.loadRulesForResource("x", config, "/");
@@ -75,10 +73,11 @@ public class FHIRMaskingProviderTest {
     list = FHIRMaskingProvider.loadRulesForResource("x", config, "/");
     assertNotNull(list);
     assertEquals(0, list.size());
-    
+
     config = new ConfigGenerator().getTestDeidConfig();
     String basePathPrefix = "/fhir/";
-    assertEquals(39, FHIRMaskingProvider.loadRulesForResource("Device", config, basePathPrefix).size());
+    assertEquals(39,
+        FHIRMaskingProvider.loadRulesForResource("Device", config, basePathPrefix).size());
   }
 
   @Ignore
@@ -200,11 +199,11 @@ public class FHIRMaskingProviderTest {
             this.getClass().getResourceAsStream("/config/fhir/patient_masking_rules.json");
         InputStream maskingProvidersStream =
             this.getClass().getResourceAsStream("/config/patient_masking_providers.json");) {
-      maskingRules = MaskingConfigUtils.readResourceFileAsString(maskingRulesStream);
-      maskingProviders = MaskingConfigUtils.readResourceFileAsString(maskingProvidersStream);
+      maskingRules = ConfigGenerator.readResourceFileAsString(maskingRulesStream);
+      maskingProviders = ConfigGenerator.readResourceFileAsString(maskingProvidersStream);
     }
 
-    DeidMaskingConfig fhirConfig = MaskingConfigUtils.getDeidConfig(maskingRules, maskingProviders);
+    DeidMaskingConfig fhirConfig = ConfigGenerator.getDeidConfig(maskingRules, maskingProviders);
     fhirConfig.setDefaultNoRuleResolution(true);
     FHIRMaskingProvider fhirMaskingProvider =
         new FHIRMaskingProvider(fhirConfig, maskingProviderFactory, tenantId);

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/fhir/GenericMaskingProviderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/fhir/GenericMaskingProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,7 +22,6 @@ import com.ibm.whc.deid.providers.masking.MaskingProviderFactory;
 import com.ibm.whc.deid.shared.pojo.config.ConfigSchemaType;
 import com.ibm.whc.deid.shared.pojo.config.DeidMaskingConfig;
 import com.ibm.whc.deid.shared.util.ConfigGenerator;
-import com.ibm.whc.deid.shared.util.MaskingConfigUtils;
 import scala.Tuple2;
 
 public class GenericMaskingProviderTest {
@@ -67,11 +66,11 @@ public class GenericMaskingProviderTest {
             this.getClass().getResourceAsStream("/config/generic/patient_masking_rules.json");
         InputStream maskingProvidersStream =
             this.getClass().getResourceAsStream("/config/patient_masking_providers.json");) {
-      maskingRules = MaskingConfigUtils.readResourceFileAsString(maskingRulesStream);
-      maskingProviders = MaskingConfigUtils.readResourceFileAsString(maskingProvidersStream);
+      maskingRules = ConfigGenerator.readResourceFileAsString(maskingRulesStream);
+      maskingProviders = ConfigGenerator.readResourceFileAsString(maskingProvidersStream);
     }
 
-    DeidMaskingConfig config = MaskingConfigUtils.getDeidConfig(maskingRules, maskingProviders);
+    DeidMaskingConfig config = ConfigGenerator.getDeidConfig(maskingRules, maskingProviders);
     config.setDefaultNoRuleResolution(true);
     config.getJson().setSchemaType(ConfigSchemaType.GEN);
     GenericMaskingProvider genericMaskingProvider =
@@ -85,9 +84,10 @@ public class GenericMaskingProviderTest {
     String filename = "/fhir/patientExample.json";
 
     System.out.println("Processing: " + filename);
-    InputStream is = this.getClass().getResourceAsStream(filename);
-
-    JsonNode node = mapper.readTree(is);
+    JsonNode node;
+    try (InputStream is = this.getClass().getResourceAsStream(filename)) {
+      node = mapper.readTree(is);
+    }
     JsonNode identifier = node.get("identifier").iterator().next();
     String originalPeriodStart = identifier.get("period").get("start").asText();
     assertEquals("2001-05-06", originalPeriodStart);

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/fhir/MaskingProviderBuilderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/fhir/MaskingProviderBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,9 +77,8 @@ public class MaskingProviderBuilderTest {
     assertTrue(device.get("expiry").isTextual());
 
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedDevice = genericMaskingProvider.mask(device);
 
@@ -94,33 +94,31 @@ public class MaskingProviderBuilderTest {
   private DeidMaskingConfig addRules(DeidMaskingConfig testMaskingConfig) {
     MaskingProviderConfig config =
         MaskingProviderConfig.getDefaultMaskingProviderConfig(MaskingProviderType.HASH);
-    Rule hashRule = MaskingConfigUtils.createRuleWithOneProvider(hashRuleName, config);
+    Rule hashRule = createRuleWithOneProvider(hashRuleName, config);
 
     MaskingProviderConfig randomConfig =
         MaskingProviderConfig.getDefaultMaskingProviderConfig(MaskingProviderType.RANDOM);
-    Rule randomRule = MaskingConfigUtils.createRuleWithOneProvider(randomRuleName, randomConfig);
+    Rule randomRule = createRuleWithOneProvider(randomRuleName, randomConfig);
 
     MaskingProviderConfig cityConfig =
         MaskingProviderConfig.getDefaultMaskingProviderConfig(MaskingProviderType.CITY);
-    Rule cityRule = MaskingConfigUtils.createRuleWithOneProvider(cityRuleName, cityConfig);
+    Rule cityRule = createRuleWithOneProvider(cityRuleName, cityConfig);
     cityConfig.setUnspecifiedValueHandling(1);
 
     DateTimeMaskingProviderConfig datetimeConfig =
         (DateTimeMaskingProviderConfig) MaskingProviderConfig
             .getDefaultMaskingProviderConfig(MaskingProviderType.DATETIME);
     datetimeConfig.setGeneralizeMonthyear(true);
-    Rule datetimeRule =
-        MaskingConfigUtils.createRuleWithOneProvider(datetimeRuleName, datetimeConfig);
+    Rule datetimeRule = createRuleWithOneProvider(datetimeRuleName, datetimeConfig);
 
     NullMaskingProviderConfig deleteConfig = (NullMaskingProviderConfig) MaskingProviderConfig
         .getDefaultMaskingProviderConfig(MaskingProviderType.NULL);
-    Rule deleteRule = MaskingConfigUtils.createRuleWithOneProvider(deleteRuleName, deleteConfig);
+    Rule deleteRule = createRuleWithOneProvider(deleteRuleName, deleteConfig);
 
     MaintainMaskingProviderConfig maintainConfig =
         (MaintainMaskingProviderConfig) MaskingProviderConfig
             .getDefaultMaskingProviderConfig(MaskingProviderType.MAINTAIN);
-    Rule maintainRule =
-        MaskingConfigUtils.createRuleWithOneProvider(maintainRuleName, maintainConfig);
+    Rule maintainRule = createRuleWithOneProvider(maintainRuleName, maintainConfig);
 
     List<Rule> rules = testMaskingConfig.getRules();
     rules.add(hashRule);
@@ -133,6 +131,20 @@ public class MaskingProviderBuilderTest {
     testMaskingConfig.setRules(rules);
 
     return testMaskingConfig;
+  }
+
+  /**
+   * Handy method to create a {@link Rule} with a single masking provider config
+   *
+   * @param name
+   * @param config
+   * @return
+   */
+  private Rule createRuleWithOneProvider(String name, MaskingProviderConfig config) {
+    List<MaskingProviderConfig> maskingProviders = new ArrayList<>();
+    maskingProviders.add(config);
+    Rule rule = new Rule(name, maskingProviders);
+    return rule;
   }
 
   @Test
@@ -152,9 +164,8 @@ public class MaskingProviderBuilderTest {
     String originalReference = "ID1";
     assertEquals(originalReference, group.get("identifier").get(1).get("value").asText());
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
     String maskedExpect0 = "74F3E37238EEEB6E9FFC731106D53C689FED464D1BDF3633C9A247D942DDD8D9";
@@ -191,9 +202,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully deleted and the rest weren't
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -236,9 +246,8 @@ public class MaskingProviderBuilderTest {
     JsonConfig jsonConfig = testMaskingConfig.getJson();
     jsonConfig.addMaskingRule("/identifier/value", hashRuleName);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     genericMaskingProvider.setDefNoRuleRes(false);
 
@@ -287,9 +296,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
@@ -334,9 +342,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     // Check that the specified item was successfully masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
@@ -362,9 +369,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -392,9 +398,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedDevice = genericMaskingProvider.mask(device);
     assertNotEquals(originalReference, maskedDevice.get("expiry").asText());
@@ -419,9 +424,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedDevice = genericMaskingProvider.mask(device);
     assertEquals(originalReference, maskedDevice.get("expiry").asText());
@@ -449,8 +453,7 @@ public class MaskingProviderBuilderTest {
     maskingConfiguration.setDatetimeYearDeleteNIntervalCompareDate("deceasedDateTime");
 
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
-    Rule dateRule =
-        MaskingConfigUtils.createRuleWithOneProvider(dateDependencyRuleName, maskingConfiguration);
+    Rule dateRule = createRuleWithOneProvider(dateDependencyRuleName, maskingConfiguration);
     List<Rule> rules = testMaskingConfig.getRules();
     rules.add(dateRule);
     testMaskingConfig.setRules(rules);
@@ -458,9 +461,8 @@ public class MaskingProviderBuilderTest {
     JsonConfig jsonConfig = testMaskingConfig.getJson();
     jsonConfig.addMaskingRule("/identifier/value", hashRuleName);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedPatient = genericMaskingProvider.mask(patient);
     assertEquals("08/12", maskedPatient.get("birthDate").asText());
@@ -481,9 +483,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
@@ -511,9 +512,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -545,9 +545,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully deleted and the rest weren't
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -576,9 +575,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
@@ -616,9 +614,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully deleted and the rest weren't
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -644,9 +641,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -673,9 +669,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -702,9 +697,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -732,9 +726,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -762,9 +755,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -788,9 +780,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -814,9 +805,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -840,9 +830,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the specified item was successfully masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -871,9 +860,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
@@ -906,9 +894,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
@@ -944,9 +931,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     String maskedExpect11 = "88CAFB31A719642B7DA0ADB63E72C015B4DCC66C4247D4EAC8CED064A8360C06";
     String maskedExpect10 = "0DD3C918ADB16575C47F4D8B27862D86EE67BD5EFB2BAFDA2AEBF661254A21A1";
@@ -987,9 +973,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     JsonNode maskedValue = genericMaskingProvider.mask(group);
     assertEquals("07/2017",
         maskedValue.get("extension").get(1).get("extension").get(0).get("valueDateTime").asText());
@@ -1015,9 +1000,8 @@ public class MaskingProviderBuilderTest {
     JsonConfig jsonConfig = testMaskingConfig.getJson();
     jsonConfig.addMaskingRule("/identifier/value", hashRuleName);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
@@ -1057,9 +1041,8 @@ public class MaskingProviderBuilderTest {
     JsonConfig jsonConfig = testMaskingConfig.getJson();
     jsonConfig.addMaskingRule("/identifier/value", hashRuleName);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
@@ -1110,9 +1093,8 @@ public class MaskingProviderBuilderTest {
     JsonConfig jsonConfig = testMaskingConfig.getJson();
     jsonConfig.addMaskingRule("/identifier/value", hashRuleName);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
     String maskedExpect01 = "9DB7D558482AF53B524217A5F4A69DE1C6F78A213782F1A41C20711B3155E4E1";
@@ -1170,9 +1152,8 @@ public class MaskingProviderBuilderTest {
     JsonConfig jsonConfig = testMaskingConfig.getJson();
     jsonConfig.addMaskingRule("/identifier/value", hashRuleName);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
@@ -1226,9 +1207,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValue = genericMaskingProvider.mask(group);
 
@@ -1263,9 +1243,8 @@ public class MaskingProviderBuilderTest {
     FHIRResourceMaskingConfiguration resourceConfiguration2 =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConf2);
 
-    MaskingProviderBuilder genericMaskingProvider2 =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration2, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider2 = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration2, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValue2 = genericMaskingProvider2.mask(group);
 
@@ -1314,9 +1293,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder maskingProviderD =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationD, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderD = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationD, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValueD = maskingProviderD.mask(groupD);
     assertEquals(maskedExpect0, maskedValueD.get("identifier").get(0).get("value").asText());
@@ -1332,9 +1310,8 @@ public class MaskingProviderBuilderTest {
     FHIRResourceMaskingConfiguration resourceConfigurationE =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfE);
 
-    MaskingProviderBuilder maskingProviderE =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationE, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderE = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationE, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     JsonNode maskedValueE = maskingProviderE.mask(groupE);
     assertEquals("ID0", maskedValueE.get("identifier").get(0).get("value").asText());
     assertEquals(maskedExpect1, maskedValueE.get("identifier").get(1).get("value").asText());
@@ -1350,9 +1327,8 @@ public class MaskingProviderBuilderTest {
     FHIRResourceMaskingConfiguration resourceConfigurationF =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfF);
 
-    MaskingProviderBuilder maskingProviderF =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationF, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderF = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationF, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValueF = maskingProviderF.mask(groupF);
     assertEquals("ID0", maskedValueF.get("identifier").get(0).get("value").asText());
@@ -1368,9 +1344,8 @@ public class MaskingProviderBuilderTest {
     FHIRResourceMaskingConfiguration resourceConfigurationG =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfG);
 
-    MaskingProviderBuilder maskingProviderG =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationG, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderG = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationG, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValueG = maskingProviderG.mask(groupG);
     assertEquals(maskedExpect0, maskedValueG.get("identifier").get(0).get("value").asText());
@@ -1401,9 +1376,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder maskingProviderA =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationA, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderA = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationA, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValueA = maskingProviderA.mask(groupA);
     assertEquals("ID0", maskedValueA.get("identifier").get(0).get("value").asText());
@@ -1419,9 +1393,8 @@ public class MaskingProviderBuilderTest {
     FHIRResourceMaskingConfiguration resourceConfigurationB =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfB);
 
-    MaskingProviderBuilder maskingProviderB =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationB, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderB = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationB, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     maskingProviderB.mask(groupB);
     assertEquals("ID0", maskedValueA.get("identifier").get(0).get("value").asText());
@@ -1436,9 +1409,8 @@ public class MaskingProviderBuilderTest {
     groupMaskConfC.put("/fhir/Group/identifier[,,,,n]/value", hashRuleName);
     FHIRResourceMaskingConfiguration resourceConfigurationC =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfC);
-    MaskingProviderBuilder maskingProviderC =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationC, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderC = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationC, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     maskingProviderC.mask(groupC);
     assertEquals("ID0", maskedValueA.get("identifier").get(0).get("value").asText());
     assertEquals("ID1", maskedValueA.get("identifier").get(1).get("value").asText());
@@ -1453,9 +1425,8 @@ public class MaskingProviderBuilderTest {
     groupMaskConfD.put("/fhir/Group/identifier[0,5]/value", hashRuleName);
     FHIRResourceMaskingConfiguration resourceConfigurationD =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfD);
-    MaskingProviderBuilder maskingProviderD =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationD, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderD = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationD, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     JsonNode maskedValueD = maskingProviderD.mask(groupD);
     assertEquals(maskedExpect0, maskedValueD.get("identifier").get(0).get("value").asText());
     assertEquals(maskedExpect1, maskedValueD.get("identifier").get(1).get("value").asText());
@@ -1470,9 +1441,8 @@ public class MaskingProviderBuilderTest {
     FHIRResourceMaskingConfiguration resourceConfigurationE =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfE);
 
-    MaskingProviderBuilder maskingProviderE =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationE, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderE = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationE, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     JsonNode maskedValueE = maskingProviderE.mask(groupE);
     assertEquals("ID0", maskedValueE.get("identifier").get(0).get("value").asText());
     assertEquals("ID1", maskedValueE.get("identifier").get(1).get("value").asText());
@@ -1487,9 +1457,8 @@ public class MaskingProviderBuilderTest {
     FHIRResourceMaskingConfiguration resourceConfigurationF =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfF);
 
-    MaskingProviderBuilder maskingProviderF =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationF, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderF = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationF, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     JsonNode maskedValueF = maskingProviderF.mask(groupF);
     assertEquals("ID0", maskedValueF.get("identifier").get(0).get("value").asText());
     assertEquals("ID1", maskedValueF.get("identifier").get(1).get("value").asText());
@@ -1510,9 +1479,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder maskingProviderA =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationA, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderA = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationA, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValueA = maskingProviderA.mask(groupA);
     assertEquals("ID0", maskedValueA.get("identifier").get(0).get("value").asText());
@@ -1527,9 +1495,8 @@ public class MaskingProviderBuilderTest {
     groupMaskConfB.put("/fhir/Group", hashRuleName);
     FHIRResourceMaskingConfiguration resourceConfigurationB =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfB);
-    MaskingProviderBuilder maskingProviderB =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationB, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderB = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationB, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     maskingProviderB.mask(groupB);
     assertEquals("ID0", maskedValueA.get("identifier").get(0).get("value").asText());
@@ -1544,9 +1511,8 @@ public class MaskingProviderBuilderTest {
     groupMaskConfC.put("/fhir/Group/identifier[n]/value", hashRuleName);
     FHIRResourceMaskingConfiguration resourceConfigurationC =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfC);
-    MaskingProviderBuilder maskingProviderC =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationC, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderC = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationC, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     maskingProviderC.mask(groupC);
     assertEquals("ID0", maskedValueA.get("identifier").get(0).get("value").asText());
@@ -1562,9 +1528,8 @@ public class MaskingProviderBuilderTest {
     groupMaskConfD.put("/fhir/Group", hashRuleName);
     FHIRResourceMaskingConfiguration resourceConfigurationD =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfD);
-    MaskingProviderBuilder maskingProviderD =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationD, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderD = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationD, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     maskingProviderD.mask(groupD);
     assertEquals("ID0", maskedValueA.get("identifier").get(0).get("value").asText());
     assertEquals("ID1", maskedValueA.get("identifier").get(1).get("value").asText());
@@ -1587,9 +1552,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder maskingProviderC =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationC, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderC = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationC, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValueC = maskingProviderC.mask(groupC);
     assertEquals("ID0", maskedValueC.get("identifier").get(0).get("value").asText());
@@ -1616,9 +1580,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder maskingProviderA =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationA, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderA = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationA, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     JsonNode maskedValueA = maskingProviderA.mask(groupA);
     assertEquals(maskedExpect0, maskedValueA.get("identifier").get(0).get("value").asText());
@@ -1633,9 +1596,8 @@ public class MaskingProviderBuilderTest {
     groupMaskConfB.put("/fhir/Group/identifier[{0}]/value", hashRuleName);
     FHIRResourceMaskingConfiguration resourceConfigurationB =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfB);
-    MaskingProviderBuilder maskingProviderB =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationB, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderB = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationB, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     JsonNode maskedValueB = maskingProviderB.mask(groupB);
     assertEquals(maskedExpect0, maskedValueB.get("identifier").get(0).get("value").asText());
     assertEquals("ID1", maskedValueB.get("identifier").get(1).get("value").asText());
@@ -1649,9 +1611,8 @@ public class MaskingProviderBuilderTest {
     groupMaskConfC.put("/fhir/Group/identifier[{0,}]/value", hashRuleName);
     FHIRResourceMaskingConfiguration resourceConfigurationC =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfC);
-    MaskingProviderBuilder maskingProviderC =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationC, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderC = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationC, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     JsonNode maskedValueC = maskingProviderC.mask(groupC);
     assertEquals(maskedExpect0, maskedValueC.get("identifier").get(0).get("value").asText());
     assertEquals("ID1", maskedValueC.get("identifier").get(1).get("value").asText());
@@ -1666,9 +1627,8 @@ public class MaskingProviderBuilderTest {
     groupMaskConfD.put("/fhir/Group/identifier[0,2]/value", hashRuleName);
     FHIRResourceMaskingConfiguration resourceConfigurationD =
         new FHIRResourceMaskingConfiguration("/fhir/Group", groupMaskConfD);
-    MaskingProviderBuilder maskingProviderD =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationD, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderD = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationD, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     JsonNode maskedValueD = maskingProviderD.mask(groupD);
     assertEquals(maskedExpect0, maskedValueD.get("identifier").get(0).get("value").asText());
     assertEquals(maskedExpect1, maskedValueD.get("identifier").get(1).get("value").asText());
@@ -1694,9 +1654,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder maskingProviderA =
-        new MaskingProviderBuilder(schemaType, resourceConfigurationA, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder maskingProviderA = new MaskingProviderBuilder(schemaType,
+        resourceConfigurationA, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     JsonNode maskedValueA = maskingProviderA.mask(groupA);
     assertEquals(maskedExpect0, maskedValueA.get("identifier").get(0).get("value").asText());
     assertEquals("ID1", maskedValueA.get("identifier").get(1).get("value").asText());
@@ -1717,9 +1676,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
     // Check that the items were not masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
     assertEquals("ID0", maskedValue.get("identifier").get(0).get("system").asText());
@@ -1744,9 +1702,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the items were not masked
     JsonNode originalCharacteristic = group.get("characteristic");
@@ -1769,9 +1726,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the items were not masked
     JsonNode originalName = group.get("name");
@@ -1794,9 +1750,8 @@ public class MaskingProviderBuilderTest {
     DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
     testMaskingConfig = addRules(testMaskingConfig);
 
-    MaskingProviderBuilder genericMaskingProvider =
-        new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-            defNoRuleRes, maskingProviderFactory, tenantId);
+    MaskingProviderBuilder genericMaskingProvider = new MaskingProviderBuilder(schemaType,
+        resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
 
     // Check that the items was masked
     JsonNode maskedValue = genericMaskingProvider.mask(group);
@@ -1822,9 +1777,8 @@ public class MaskingProviderBuilderTest {
       DeidMaskingConfig testMaskingConfig = (new ConfigGenerator()).getTestDeidConfig();
       testMaskingConfig = addRules(testMaskingConfig);
 
-      MaskingProviderBuilder maskingProvider =
-          new MaskingProviderBuilder(schemaType, resourceConfiguration, testMaskingConfig,
-              defNoRuleRes, maskingProviderFactory, tenantId);
+      MaskingProviderBuilder maskingProvider = new MaskingProviderBuilder(schemaType,
+          resourceConfiguration, testMaskingConfig, defNoRuleRes, maskingProviderFactory, tenantId);
       maskingProvider.mask(group);
       isSuccessful = true;
     } catch (IllegalArgumentException e) {

--- a/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/masking/ConditionalMaskingProviderConfig.java
+++ b/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/masking/ConditionalMaskingProviderConfig.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -40,11 +40,19 @@ public class ConditionalMaskingProviderConfig extends MaskingProviderConfig {
       throw new InvalidMaskingConfigurationException(
           "`maskRuleSet` must be specified with at least one entry");
     }
+    int offset = 0;
     for (ConditionalMaskRuleSet ruleSet : maskRuleSet) {
       if (ruleSet == null) {
-        throw new InvalidMaskingConfigurationException("entry in `maskRuleSet` is null");
+        throw new InvalidMaskingConfigurationException(
+            "entry at offset " + Integer.toString(offset) + " in `maskRuleSet` is null");
       }
-      ruleSet.validate("maskRuleSet");
+      try {
+        ruleSet.validate("maskRuleSet");
+      } catch (InvalidMaskingConfigurationException e) {
+        throw new InvalidMaskingConfigurationException("entry at offset " + Integer.toString(offset)
+            + " in `maskRuleSet` is not valid: " + e.getMessage());
+      }
+      offset++;
     }
   }
 

--- a/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/masking/PhoneMaskingProviderConfig.java
+++ b/whc-shared/src/main/java/com/ibm/whc/deid/shared/pojo/config/masking/PhoneMaskingProviderConfig.java
@@ -1,11 +1,13 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.ibm.whc.deid.shared.pojo.config.masking;
 
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.ibm.whc.deid.shared.pojo.masking.MaskingProviderType;
@@ -66,6 +68,22 @@ public class PhoneMaskingProviderConfig extends MaskingProviderConfig {
     super.validate();
     if (invNdigitsReplaceWith == null) {
       throw new InvalidMaskingConfigurationException("`invNdigitsReplaceWith` must be not null");
+    }
+    if (phoneRegexPatterns != null) {
+      int offset = 0;
+      for (String regx : phoneRegexPatterns) {
+        if (regx == null || regx.trim().isEmpty()) {
+          throw new InvalidMaskingConfigurationException(
+              "pattern at offset " + offset + " in `phoneRegexPatterns` is empty");
+        }
+        try {
+          Pattern.compile(regx);
+        } catch (PatternSyntaxException e) {
+          throw new InvalidMaskingConfigurationException("pattern at offset " + offset
+              + " in `phoneRegexPatterns` is not valid: " + e.getMessage());
+        }
+        offset++;
+      }
     }
   }
 

--- a/whc-shared/src/main/java/com/ibm/whc/deid/shared/util/MaskingConfigUtils.java
+++ b/whc-shared/src/main/java/com/ibm/whc/deid/shared/util/MaskingConfigUtils.java
@@ -1,202 +1,31 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.ibm.whc.deid.shared.util;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ibm.whc.deid.ObjectMapperFactory;
-import com.ibm.whc.deid.shared.pojo.config.ConfigSchemaType;
 import com.ibm.whc.deid.shared.pojo.config.DeidMaskingConfig;
 import com.ibm.whc.deid.shared.pojo.config.Rule;
 import com.ibm.whc.deid.shared.pojo.config.json.JsonConfig;
 import com.ibm.whc.deid.shared.pojo.config.json.JsonMaskingRule;
-import com.ibm.whc.deid.shared.pojo.config.masking.ConfigConstant;
 import com.ibm.whc.deid.shared.pojo.config.masking.MaskingProviderConfig;
-import com.ibm.whc.deid.shared.pojo.masking.MaskingProviderType;
 import com.ibm.whc.deid.shared.pojo.masking.MaskingProviderType.MaskingProviderCategory;
 
 /*
- * Utility class for masking config functionality
+ * Class containing masking configuration utilities
  */
 public class MaskingConfigUtils {
-
-  private static final Logger logger = LoggerFactory.getLogger(MaskingConfigUtils.class);
 
   private static final MaskingConfigUtils _instance = new MaskingConfigUtils();
 
   public static MaskingConfigUtils getInstance() {
     return _instance;
-  }
-
-  /**
-   * Get a DeidMaskingConfig for testing
-   *
-   * @param maskingRules
-   * @param maskingProviders
-   * @return
-   */
-  public static DeidMaskingConfig getDeidConfig(String maskingRules, String maskingProviders) {
-
-    DeidMaskingConfig config = new DeidMaskingConfig();
-
-    List<Rule> rules = getFhirRules(maskingProviders);
-    config.setRules(rules);
-
-    config.setJson(getDefaultFhirConfig(maskingRules));
-
-    return config;
-  }
-
-  /**
-   * Handy method to create a {@link Rule} with a single masking provider config
-   *
-   * @param name
-   * @param config
-   * @return
-   */
-  public static Rule createRuleWithOneProvider(String name, MaskingProviderConfig config) {
-    List<MaskingProviderConfig> maskingProviders = new ArrayList<>();
-    maskingProviders.add(config);
-    Rule rule = new Rule(name, maskingProviders);
-    return rule;
-  }
-
-  /**
-   * Get a set of default rules
-   *
-   * @return
-   */
-  public static List<Rule> getFhirRules(String maskingProviders) {
-    List<Rule> rules = new ArrayList<>();
-    ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
-
-    try {
-      JsonNode providers = mapper.readTree(maskingProviders);
-
-      Iterator<Entry<String, JsonNode>> jsonFields = providers.fields();
-      while (jsonFields.hasNext()) {
-        Entry<String, JsonNode> field = jsonFields.next();
-        String ruleName = field.getKey();
-        String type = null;
-        JsonNode defaultMaskingProvider =
-            field.getValue().get(ConfigConstant.DEFAULT_MASKING_PROVIDER);
-        if (defaultMaskingProvider != null) {
-          type = defaultMaskingProvider.asText();
-          MaskingProviderConfig config = MaskingProviderConfig
-              .getDefaultMaskingProviderConfig(MaskingProviderType.valueOf(type));
-          Rule rule = createRuleWithOneProvider(ruleName, config);
-
-          rules.add(rule);
-        }
-      }
-    } catch (IOException e) {
-      logger.error(e.getMessage(), e);
-    }
-
-    return rules;
-  }
-
-  /**
-   * Read a resource file as one string.
-   *
-   * @param resource
-   * @return
-   * @throws IOException
-   */
-  public static String readResourceFileAsString(String resource) throws IOException {
-    try (InputStream is = MaskingConfigUtils.class.getResourceAsStream(resource)) {
-      try (InputStreamReader isr = new InputStreamReader(is);
-          BufferedReader reader = new BufferedReader(isr)) {
-        return reader.lines().collect(Collectors.joining());
-      }
-    }
-  }
-
-  /**
-   * Read an InputStream as one string
-   *
-   * @param is
-   * @return
-   * @throws IOException
-   */
-  public static String readResourceFileAsString(InputStream is) throws IOException {
-    try (InputStreamReader isr = new InputStreamReader(is);
-        BufferedReader reader = new BufferedReader(isr)) {
-      return reader.lines().collect(Collectors.joining());
-    }
-  }
-
-  /**
-   * Get the default fhir masking rules.
-   *
-   * @return
-   */
-  public static List<JsonMaskingRule> getDefaultFhirMaskingRules(String maskingRulesJson) {
-    List<JsonMaskingRule> maskingRules = new ArrayList<>();
-    ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
-    try {
-
-      JsonNode providers = mapper.readTree(maskingRulesJson);
-
-      Iterator<Entry<String, JsonNode>> jsonFields = providers.fields();
-      while (jsonFields.hasNext()) {
-        Entry<String, JsonNode> field = jsonFields.next();
-        String jsonPath = field.getKey();
-        String rule = field.getValue().asText();
-
-        JsonMaskingRule maskingRule = new JsonMaskingRule(jsonPath, rule);
-        maskingRules.add(maskingRule);
-      }
-    } catch (IOException e) {
-      logger.error(e.getMessage(), e);
-    }
-    return maskingRules;
-  }
-
-  /**
-   * Get MessageTypes for FHIR. Used for testing
-   *
-   * @return
-   */
-  public static List<String> getFhirTestMessageTypes() {
-    String[] messageTypes = {"Questionnaire", "Device", "DeviceMetric", "DeviceComponent",
-        "Patient", "Practitioner", "Location", "Organization", "Observation", "Medication",
-        "MedicationOrder", "MedicationAdministration", "Contract", "QuestionnaireResponse",
-        "BodySite", "Group", "CarePlan", "AuditEvent",};
-
-    return Arrays.asList(messageTypes);
-  }
-
-  public static JsonConfig getDefaultFhirConfig(String maskingRules) {
-    JsonConfig jsonConfig = new JsonConfig();
-
-    jsonConfig.setMessageTypes(getFhirTestMessageTypes());
-
-    jsonConfig.setSchemaType(ConfigSchemaType.FHIR);
-
-    // For most of existing test cases, we use resourceType
-    jsonConfig.setMessageTypeKey("resourceType");
-
-    jsonConfig.setMaskingRules(getDefaultFhirMaskingRules(maskingRules));
-
-    return jsonConfig;
   }
 
   /**
@@ -396,10 +225,10 @@ public class MaskingConfigUtils {
 
         if (!ruleNames.add(ruleName)) {
           throw new InvalidMaskingConfigurationException(
-              "invalid masking configuration: the value of the `" + Rule.NAME_PROPERTY_NAME
-                  + "` property in the rule at offset " + offset + " in `"
+              "invalid masking configuration: the value `" + ruleName + "` is used for the `"
+                  + Rule.NAME_PROPERTY_NAME + "` property on multiple rules in the `"
                   + DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME
-                  + "` has already been used by another rule",
+                  + "` list - rule names must be unique",
               DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME + "." + Rule.NAME_PROPERTY_NAME);
         }
 
@@ -407,7 +236,8 @@ public class MaskingConfigUtils {
         if (providers == null || providers.isEmpty()) {
           throw new InvalidMaskingConfigurationException(
               "invalid masking configuration: the `" + Rule.PROVIDERS_PROPERTY_NAME
-                  + "` property is missing from the rule at offset " + offset + " in `"
+                  + "` property is missing from the rule with `" + Rule.NAME_PROPERTY_NAME
+                  + "` value `" + ruleName + "` in `"
                   + DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME + "`",
               DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME + "."
                   + Rule.PROVIDERS_PROPERTY_NAME);
@@ -416,8 +246,8 @@ public class MaskingConfigUtils {
         if (providers.size() > 2) {
           throw new InvalidMaskingConfigurationException(
               "invalid masking configuration: too many entries in `" + Rule.PROVIDERS_PROPERTY_NAME
-                  + "` for the rule at offset " + offset + " in `"
-                  + DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME
+                  + "` for the rule with `" + Rule.NAME_PROPERTY_NAME + "` value `" + ruleName
+                  + "` in `" + DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME
                   + "` - the maximum allowed is 2",
               DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME + "."
                   + Rule.PROVIDERS_PROPERTY_NAME);
@@ -426,12 +256,25 @@ public class MaskingConfigUtils {
         int providerOffset = 0;
         for (MaskingProviderConfig provider : providers) {
           if (provider == null) {
-            throw new InvalidMaskingConfigurationException(
-                "invalid masking configuration: the masking provider at offset " + providerOffset
-                    + " in `" + Rule.PROVIDERS_PROPERTY_NAME + "` for the rule at offset " + offset
-                    + " in `" + DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME + "` is null",
-                DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME + "."
-                    + Rule.PROVIDERS_PROPERTY_NAME);
+            StringBuilder buffer = new StringBuilder(200);
+            buffer.append(DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME);
+            buffer.append('.');
+            buffer.append(Rule.PROVIDERS_PROPERTY_NAME);
+            String location = buffer.toString();
+            buffer.setLength(0);
+            buffer.append("invalid masking configuration: the ");
+            buffer.append(providerOffset == 0 ? "first" : "second");
+            buffer.append(" masking provider in `");
+            buffer.append(Rule.PROVIDERS_PROPERTY_NAME);
+            buffer.append("` for the rule with `");
+            buffer.append(Rule.NAME_PROPERTY_NAME);
+            buffer.append("` value `");
+            buffer.append(ruleName);
+            buffer.append("` in `");
+            buffer.append(DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME);
+            buffer.append("` is null");
+            String message = buffer.toString();
+            throw new InvalidMaskingConfigurationException(message, location);
           }
 
           // the `type` property in each masking provider could not have been deserialized without
@@ -440,17 +283,29 @@ public class MaskingConfigUtils {
           try {
             provider.validate();
           } catch (InvalidMaskingConfigurationException e) {
-            String location = DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME + "."
-                + Rule.PROVIDERS_PROPERTY_NAME;
+            StringBuilder buffer = new StringBuilder(200);
+            buffer.append(DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME);
+            buffer.append('.');
+            buffer.append(Rule.PROVIDERS_PROPERTY_NAME);
             if (e.getLocation() != null) {
-              location += ("." + e.getLocation());
+              buffer.append('.').append(e.getLocation());
             }
-            throw new InvalidMaskingConfigurationException(
-                "invalid masking configuration: the masking provider at offset " + providerOffset
-                    + " in `" + Rule.PROVIDERS_PROPERTY_NAME + "` for the rule at offset " + offset
-                    + " in `" + DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME
-                    + "` is not valid: " + e.getMessage(),
-                e, location);
+            String location = buffer.toString();
+            buffer.setLength(0);
+            buffer.append("invalid masking configuration: the ");
+            buffer.append(providerOffset == 0 ? "first" : "second");
+            buffer.append(" masking provider in `");
+            buffer.append(Rule.PROVIDERS_PROPERTY_NAME);
+            buffer.append("` for the rule with `");
+            buffer.append(Rule.NAME_PROPERTY_NAME);
+            buffer.append("` value `");
+            buffer.append(ruleName);
+            buffer.append("` in `");
+            buffer.append(DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME);
+            buffer.append("` is not valid: ");
+            buffer.append(e.getMessage());
+            String message = buffer.toString();
+            throw new InvalidMaskingConfigurationException(message, e, location);
           }
 
           providerOffset++;
@@ -459,7 +314,8 @@ public class MaskingConfigUtils {
         if (providers.size() == 2) {
           if (providers.get(0).getType().getCategory() == MaskingProviderCategory.CategoryII) {
             throw new InvalidMaskingConfigurationException(
-                "invalid masking configuration: the rule at offset " + offset + " in `"
+                "invalid masking configuration: the rule with `" + Rule.NAME_PROPERTY_NAME
+                    + "` value `" + ruleName + "` in `"
                     + DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME
                     + "` contains multiple masking providers, but the first masking provider is not a Category I provider",
                 DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME + "."
@@ -467,7 +323,8 @@ public class MaskingConfigUtils {
           }
           if (providers.get(1).getType().getCategory() == MaskingProviderCategory.CategoryI) {
             throw new InvalidMaskingConfigurationException(
-                "invalid masking configuration: the rule at offset " + offset + " in `"
+                "invalid masking configuration: the rule with `" + Rule.NAME_PROPERTY_NAME
+                    + "` value `" + ruleName + "` in `"
                     + DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME
                     + "` contains multiple masking providers, but the second masking provider is not a Category II provider",
                 DeidMaskingConfig.RULES_CONFIGURATION_PROPERTY_NAME + "."

--- a/whc-shared/src/test/java/com/ibm/whc/deid/shared/pojo/config/masking/ConditionalMaskingProviderConfigTest.java
+++ b/whc-shared/src/test/java/com/ibm/whc/deid/shared/pojo/config/masking/ConditionalMaskingProviderConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -45,10 +45,29 @@ public class ConditionalMaskingProviderConfigTest {
       config.validate();
       fail("expected exception");
     } catch (InvalidMaskingConfigurationException e) {
-      assertEquals("`maskRuleSet.maskingProvider` is missing", e.getMessage());
+      assertEquals(
+          "entry at offset 0 in `maskRuleSet` is not valid: `maskRuleSet.maskingProvider` is missing",
+          e.getMessage());
     }
 
     ruleset.setMaskingProvider(new HashMaskingProviderConfig());
+    config.validate();
+
+    ConditionalMaskRuleSet ruleset2 = new ConditionalMaskRuleSet();
+    maskRuleSet.add(ruleset2);
+    BinningMaskingProviderConfig provider = new BinningMaskingProviderConfig();
+    provider.setBinSize(-2);
+    ruleset2.setMaskingProvider(provider);
+    try {
+      config.validate();
+      fail("expected exception");
+    } catch (InvalidMaskingConfigurationException e) {
+      assertEquals(
+          "entry at offset 1 in `maskRuleSet` is not valid: `maskRuleSet.maskingProvider` is invalid: `binSize` must be greater than 0",
+          e.getMessage());
+    }
+
+    provider.setBinSize(10);
     config.validate();
 
     config.setUnspecifiedValueHandling(5);
@@ -66,7 +85,7 @@ public class ConditionalMaskingProviderConfigTest {
       config.validate();
       fail("expected exception");
     } catch (InvalidMaskingConfigurationException e) {
-      assertEquals("entry in `maskRuleSet` is null", e.getMessage());
+      assertEquals("entry at offset 2 in `maskRuleSet` is null", e.getMessage());
     }
   }
 

--- a/whc-shared/src/test/java/com/ibm/whc/deid/shared/pojo/masking/PhoneMaskingProviderConfigTest.java
+++ b/whc-shared/src/test/java/com/ibm/whc/deid/shared/pojo/masking/PhoneMaskingProviderConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,8 @@ package com.ibm.whc.deid.shared.pojo.masking;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Test;
 import com.ibm.whc.deid.shared.pojo.config.masking.PhoneMaskingProviderConfig;
 import com.ibm.whc.deid.shared.util.InvalidMaskingConfigurationException;
@@ -18,6 +20,7 @@ public class PhoneMaskingProviderConfigTest {
   public void testValidate() throws Exception {
     PhoneMaskingProviderConfig config = new PhoneMaskingProviderConfig();
     config.validate();
+
     config.setUnspecifiedValueHandling(-1);
     try {
       config.validate();
@@ -27,6 +30,7 @@ public class PhoneMaskingProviderConfigTest {
     }
     config.setUnspecifiedValueHandling(0);
     config.validate();
+
     config.setInvNdigitsReplaceWith(null);
     try {
       config.validate();
@@ -35,6 +39,40 @@ public class PhoneMaskingProviderConfigTest {
       assertTrue(e.getMessage().contains("`invNdigitsReplaceWith` must be not null"));
     }
     config.setInvNdigitsReplaceWith("1");
+    config.validate();
+
+    List<String> patterns = new ArrayList<>();
+    config.setPhoneRegexPatterns(patterns);
+    patterns.add("[0-9");
+    try {
+      config.validate();
+      fail("expected exception");
+    } catch (InvalidMaskingConfigurationException e) {
+      assertTrue(
+          e.getMessage().startsWith("pattern at offset 0 in `phoneRegexPatterns` is not valid: "));
+    }
+    patterns.clear();
+    patterns.add("^(?<prefix>\\+|00)(?<countryCode>\\d{1,3})(?<separator>-| )(?<number>\\d+)");
+    patterns.add(
+        "^(?<prefix>\\+|00)(?<countryCode>\\d{1,3})(?<separator>-| )(?<number>\\(\\d+\\))\\d+");
+    config.validate();
+    patterns.add(null);
+    try {
+      config.validate();
+      fail("expected exception");
+    } catch (InvalidMaskingConfigurationException e) {
+      assertEquals("pattern at offset 2 in `phoneRegexPatterns` is empty", e.getMessage());
+    }
+    patterns.remove(2);
+    patterns.add("  \t");
+    try {
+      config.validate();
+      fail("expected exception");
+    } catch (InvalidMaskingConfigurationException e) {
+      assertEquals("pattern at offset 2 in `phoneRegexPatterns` is empty", e.getMessage());
+    }
+    patterns.remove(2);
+    patterns.add("[0-9]*");
     config.validate();
   }
 }

--- a/whc-shared/src/test/java/com/ibm/whc/deid/shared/util/ConfigGenerator.java
+++ b/whc-shared/src/test/java/com/ibm/whc/deid/shared/util/ConfigGenerator.java
@@ -1,16 +1,33 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.ibm.whc.deid.shared.util;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ibm.whc.deid.ObjectMapperFactory;
+import com.ibm.whc.deid.shared.pojo.config.ConfigSchemaType;
 import com.ibm.whc.deid.shared.pojo.config.DeidMaskingConfig;
 import com.ibm.whc.deid.shared.pojo.config.Rule;
+import com.ibm.whc.deid.shared.pojo.config.json.JsonConfig;
+import com.ibm.whc.deid.shared.pojo.config.json.JsonMaskingRule;
+import com.ibm.whc.deid.shared.pojo.config.masking.ConfigConstant;
+import com.ibm.whc.deid.shared.pojo.config.masking.MaskingProviderConfig;
+import com.ibm.whc.deid.shared.pojo.masking.MaskingProviderType;
 
 public class ConfigGenerator {
 
@@ -29,14 +46,14 @@ public class ConfigGenerator {
     DeidMaskingConfig config = getNewMaskingConfig();
     try {
       String maskingProviders =
-          MaskingConfigUtils.readResourceFileAsString("/template/fhir_masking_providers.json");
+          ConfigGenerator.readResourceFileAsString("/template/fhir_masking_providers.json");
       String maskingRules =
-          MaskingConfigUtils.readResourceFileAsString("/template/fhir_masking_rules.json");
+          ConfigGenerator.readResourceFileAsString("/template/fhir_masking_rules.json");
 
-      List<Rule> rules = MaskingConfigUtils.getFhirRules(maskingProviders);
+      List<Rule> rules = ConfigGenerator.getFhirRules(maskingProviders);
       config.setRules(rules);
 
-      config.setJson(MaskingConfigUtils.getDefaultFhirConfig(maskingRules));
+      config.setJson(ConfigGenerator.getDefaultFhirConfig(maskingRules));
 
     } catch (IOException e) {
       logger.error(e.getMessage(), e);
@@ -44,4 +61,157 @@ public class ConfigGenerator {
     return config;
   }
 
+  /**
+   * Get a DeidMaskingConfig for testing
+   *
+   * @param maskingRules
+   * @param maskingProviders
+   * @return
+   */
+  public static DeidMaskingConfig getDeidConfig(String maskingRules, String maskingProviders) {
+
+    DeidMaskingConfig config = new DeidMaskingConfig();
+
+    List<Rule> rules = getFhirRules(maskingProviders);
+    config.setRules(rules);
+
+    config.setJson(getDefaultFhirConfig(maskingRules));
+
+    return config;
+  }
+
+  /**
+   * Get a set of default rules
+   *
+   * @return
+   */
+  public static List<Rule> getFhirRules(String maskingProviders) {
+    List<Rule> rules = new ArrayList<>();
+    ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
+
+    try {
+      JsonNode providers = mapper.readTree(maskingProviders);
+
+      Iterator<Entry<String, JsonNode>> jsonFields = providers.fields();
+      while (jsonFields.hasNext()) {
+        Entry<String, JsonNode> field = jsonFields.next();
+        String ruleName = field.getKey();
+        String type = null;
+        JsonNode defaultMaskingProvider =
+            field.getValue().get(ConfigConstant.DEFAULT_MASKING_PROVIDER);
+        if (defaultMaskingProvider != null) {
+          type = defaultMaskingProvider.asText();
+          MaskingProviderConfig config = MaskingProviderConfig
+              .getDefaultMaskingProviderConfig(MaskingProviderType.valueOf(type));
+          Rule rule = createRuleWithOneProvider(ruleName, config);
+
+          rules.add(rule);
+        }
+      }
+    } catch (IOException e) {
+      logger.error(e.getMessage(), e);
+    }
+
+    return rules;
+  }
+
+  /**
+   * Handy method to create a {@link Rule} with a single masking provider config
+   *
+   * @param name
+   * @param config
+   * @return
+   */
+  public static Rule createRuleWithOneProvider(String name, MaskingProviderConfig config) {
+    List<MaskingProviderConfig> maskingProviders = new ArrayList<>();
+    maskingProviders.add(config);
+    Rule rule = new Rule(name, maskingProviders);
+    return rule;
+  }
+
+  public static JsonConfig getDefaultFhirConfig(String maskingRules) {
+    JsonConfig jsonConfig = new JsonConfig();
+
+    jsonConfig.setMessageTypes(getFhirTestMessageTypes());
+
+    jsonConfig.setSchemaType(ConfigSchemaType.FHIR);
+
+    // For most of existing test cases, we use resourceType
+    jsonConfig.setMessageTypeKey("resourceType");
+
+    jsonConfig.setMaskingRules(getDefaultFhirMaskingRules(maskingRules));
+
+    return jsonConfig;
+  }
+
+  /**
+   * Get MessageTypes for FHIR. Used for testing
+   *
+   * @return
+   */
+  public static List<String> getFhirTestMessageTypes() {
+    String[] messageTypes = {"Questionnaire", "Device", "DeviceMetric", "DeviceComponent",
+        "Patient", "Practitioner", "Location", "Organization", "Observation", "Medication",
+        "MedicationOrder", "MedicationAdministration", "Contract", "QuestionnaireResponse",
+        "BodySite", "Group", "CarePlan", "AuditEvent",};
+
+    return Arrays.asList(messageTypes);
+  }
+
+  /**
+   * Get the default fhir masking rules.
+   *
+   * @return
+   */
+  public static List<JsonMaskingRule> getDefaultFhirMaskingRules(String maskingRulesJson) {
+    List<JsonMaskingRule> maskingRules = new ArrayList<>();
+    ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
+    try {
+
+      JsonNode providers = mapper.readTree(maskingRulesJson);
+
+      Iterator<Entry<String, JsonNode>> jsonFields = providers.fields();
+      while (jsonFields.hasNext()) {
+        Entry<String, JsonNode> field = jsonFields.next();
+        String jsonPath = field.getKey();
+        String rule = field.getValue().asText();
+
+        JsonMaskingRule maskingRule = new JsonMaskingRule(jsonPath, rule);
+        maskingRules.add(maskingRule);
+      }
+    } catch (IOException e) {
+      logger.error(e.getMessage(), e);
+    }
+    return maskingRules;
+  }
+
+  /**
+   * Read a resource file as one string.
+   *
+   * @param resource
+   * @return
+   * @throws IOException
+   */
+  public static String readResourceFileAsString(String resource) throws IOException {
+    try (InputStream is = MaskingConfigUtils.class.getResourceAsStream(resource)) {
+      try (InputStreamReader isr = new InputStreamReader(is);
+          BufferedReader reader = new BufferedReader(isr)) {
+        return reader.lines().collect(Collectors.joining());
+      }
+    }
+  }
+
+  /**
+   * Read an InputStream as one string
+   *
+   * @param is
+   * @return
+   * @throws IOException
+   */
+  public static String readResourceFileAsString(InputStream is) throws IOException {
+    try (InputStreamReader isr = new InputStreamReader(is);
+        BufferedReader reader = new BufferedReader(isr)) {
+      return reader.lines().collect(Collectors.joining());
+    }
+  }
 }


### PR DESCRIPTION
1. Use rule name where possible instead of offsets in masking configuration validation messages
2. Identify offset of mask rule set in CONDITIONAL rules if a masking provider in a mask rule set fails validation
3. Add additional validation to PHONE provider configuration
4. Relocate code in the masking configuration validation class that is now used only for testing