### PR TITLE
Support partial date patterns in DATETIME provider

### DIFF
--- a/docs/masking-providers.md
+++ b/docs/masking-providers.md
@@ -946,23 +946,23 @@ The values in the examples are for demonstration purposes only.
    
 ```
 
->   In the example above, a rule consisting of two value sets is applied to the
->   Patient address city data element. The value sets are examined sequentially as
->   follows:
+In the example above, a rule consisting of two value sets is applied to the
+Patient address city data element. The value sets are examined sequentially as
+follows:
 
-> 1.  If the city value of the data element is one of the cities listed in
+1.  If the city value of the data element is one of the cities listed in
     the sourceValueIn property of the first value set (that is, any of **Bangkok**,
     **Manila**, **Shanghai**, **Taipei**, or **Mumbai**), then it is replaced with
     the value specified in the targetValue property value (that is, **Asian City**).
     No other value sets are examined.
     
-> 2.  Otherwise, if the city value of the data element is one of the cities listed
+1.  Otherwise, if the city value of the data element is one of the cities listed
     in the sourceValueIn property of the second value set (that is, **Addis Ababa**,
     **Cairo**, **Cape Town**, or **Lagos**), then it is replaced with the value
     specified in the targetValue property (that is, **African City**). No other value 
     sets, if any, are examined.
 
-> 3.  Otherwise, since the city value of the data element has not been matched and
+1.  Otherwise, since the city value of the data element has not been matched and
     there are no more value sets to examine, the original value is maintained.
 
 **Example 5: Generalize example with special value**
@@ -1380,19 +1380,19 @@ Here are the options and their default values for the PSEUDONYM  provider:
 
 #### RANDOM
 
->   Replaces an original data value with random characters, by:
+Replaces an original data value with random characters, by:
 
-> 1.  Replacing numerical characters with numerical characters;
+1.  Replacing numerical characters with numerical characters;
 
-> 2.  Replacing letter characters with letter characters;
+1.  Replacing letter characters with letter characters;
 
-> 3.  Maintaining other characters, for example, commas, dashes, and asterisks.
+1.  Maintaining other characters, for example, commas, dashes, and asterisks.
 
->   If non-English characters are replaced, the characters are replaced with an
->   appropriately-cased Latin letter. If the character does not have an associated case,
->   such as Chinese or Japanese characters, it is replaced with an uppercase Latin letter.
+If non-English characters are replaced, the characters are replaced with an
+appropriately-cased Latin letter. If the character does not have an associated case,
+such as Chinese or Japanese characters, it is replaced with an uppercase Latin letter.
 
-  This provider has no configuration options.
+This provider has no configuration options.
 
 #### REDACT
 
@@ -1516,19 +1516,19 @@ Here are the options and their default values for the PSEUDONYM  provider:
 >   If multiple options are set to **True** in the postal code masking algorithm, the
 >   operations are performed in this order:
 
-> 1.  Replace the postal code with a neighboring postal code (approximate geographic distance)
+1.  Replace the postal code with a neighboring postal code (approximate geographic distance)
 
-> 2.  Zero out the postal code's three-digit prefix if the total population in the
+2.  Zero out the postal code's three-digit prefix if the total population in the
     geographical unit, formulated by combining all postal codes with the same
     three-digit prefix as the original postal code, contains less than a specified
     minimum population. Additionally, the postal code may be truncated to a
     specified length if the minimum population in the formulated geographical
     unit is not reached.
 
-> 3.  Replace the postal code digits suffix either with random digits, or with digits that
+3.  Replace the postal code digits suffix either with random digits, or with digits that
     result in a random valid postal code with the same prefix.
 
-> 4.  Truncate the postal code to the prefix.
+4.  Truncate the postal code to the prefix.
 
 | **Option name**                      | **Type** | **Description**                                                                   | **Default value** |
 |--------------------------------------|----------|-----------------------------------------------------------------------------------|-------------------|

--- a/docs/masking-providers.md
+++ b/docs/masking-providers.md
@@ -387,46 +387,45 @@ This privacy provider supports these options:
 
 #### DATETIME
 
->   Masks datetime (timestamp) objects. There are several options supported,
->   for example, shifting dates, generalizing to month, and generalizing to year.
->   Additional options include adding random offsets to the various datetime
->   elements, for example, years, months, days, hours, and seconds). If
->   multiple options are set to true in the datetime masking algorithm, the
->   following order is respected.
+Masks datetime (timestamp) objects. There are several options supported,
+for example, shifting dates, generalizing to month, and generalizing to year.
+Additional options include adding random offsets to the various datetime
+elements, for example, years, months, days, hours, and seconds). If
+multiple options are set to true in the datetime masking algorithm, the
+following order is respected.
 
->  These examples are for the 10th of January 2016:
+These examples are for the 10th of January 2016:
 
-> 1.  Override with default or specified value, for example, **90+** or **Over 90 y.o.**.
+1.  Override with default or specified value, for example, **90+** or **Over 90 y.o.**.
 
-> 2.  Shift the date by constant amount.
+2.  Shift the date by constant amount.
 
-> 3.  Generalize to week number/year, for example, 02/2016.
+3.  Generalize to week number/year, for example, 02/2016.
 
-> 4.  Generalize to month/year, for example, 01/2016.
+4.  Generalize to month/year, for example, 01/2016.
 
-> 5.  Generalize to quarter year, for example, 01/2016.
+5.  Generalize to quarter year, for example, 01/2016.
 
-> 6.  Generalize to year, for example, 2016.
+6.  Generalize to year, for example, 2016.
 
-> 7.  Generalize to N-year interval, for example, 2015-2019.
+7.  Generalize to N-year interval, for example, 2015-2019.
 
-> 8.  Generalize to year (for example, 1927) and mask any age over 90.
+8.  Generalize to year (for example, 1927) and mask any age over 90.
 
-> 9.  Generalize to month/year (for example, 02/1927) and mask any age over 90.
+9.  Generalize to month/year (for example, 02/1927) and mask any age over 90.
 
-> 10. Add random offsets to year, month, day, hour, minutes, and seconds.
+10. Add random offsets to year, month, day, hour, minutes, and seconds.
 
-> 11. Apply maximum years ago.
+11. Apply maximum years ago.
 
-> 12. Apply maximum days ago.
+12. Apply maximum days ago.
 
-   If the override option of the provider is set to **True**, then the override
-   is processed first. If the rule criteria are met, all other options
-   of the DATETIME provider are ignored.
+If the override option of the provider is set to **True**, then the override
+is processed first. If the rule criteria are met, all other options
+of the DATETIME provider are ignored.
 
 
-   The following date formats are supported by the DATETIME masking provider.
-   This uses the option datetime.format.fixed:
+The following formats are supported by the DATETIME masking provider by default:
 
 | **Supported date / datetime format**         | **Example of recognized input value** |
 |----------------------------------------------|---------------------------------------|
@@ -441,6 +440,7 @@ This privacy provider supports these options:
 | dd/MM/yyyy[ HH:mm:ss ]                       | 24/12/2018 12:01:12                   |
 | yyyy/MM/dd[ HH:mm:ss ]                       | 2018/12/24 12:01:12                   |
 
+
  The DATETIME masking provider supports the following configuration options.
 
 **Options to change the recognized date and time formats**
@@ -448,6 +448,10 @@ This privacy provider supports these options:
 | **Option name**                                   | **Type** | **Description**                                                                                                                                                                                                                                                  | **Default value** |
 |---------------------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
 | formatFixed                                       | String   | Datetime format                                                                                                                                                                                                                                                  | null              |
+
+If a value for `formatFixed` is provided, it will be the only format the privacy provider will recognize.  The format must at minimum include a year component.  The given value must be valid as per the java.time.format.DateTimeFormatter class.
+
+
 **Options to return a fixed value if the year is a given number of years ago**
    
 | **Option name**                                   | **Type** | **Description**                                                                                                                                                                                                                                                  | **Default value** |
@@ -1133,20 +1137,20 @@ The values in the examples are for demonstration purposes only.
 
 #### NUMBERVARIANCE
 
->   Masks a numeric data value by adding a random offset. There are two options
->   available. These are processed in the following order:
+Masks a numeric data value by adding a random offset. There are two options
+available. These are processed in the following order:
 
-> 1.  Calculating the offset by randomly selecting a numeric value from within a
+1.  Calculating the offset by randomly selecting a numeric value from within a
     pre-specified interval / range.
 
-> 2.  Calculating the offset based on given percentages signifying the acceptable
+2.  Calculating the offset based on given percentages signifying the acceptable
     distance of the new value from the original value.
 
 | **Option name**                 | **Type** | **Description**                                                                                 | **Default value** |
 |---------------------------------|----------|-------------------------------------------------------------------------------------------------|-------------------|
 | augmentMask                     | Boolean  | Augment the numeric data value                                                                  | false             |
 | augmentLowerBound               | double   | Range interval lower bound                                                                      | 1.0               |
-| augmentUpperBound               | double   | Range interval upper bound                                                                      | 10.               |
+| augmentUpperBound               | double   | Range interval upper bound                                                                      | 10.0               |
 | resultWithPrecision             | Boolean  | Result includes decimal digits for precision                                                    | false             |
 | precisionDigits                 | Integer  | Number of decimal digits to keep when precision is set to true; -1 to provide maximum precision | -1                |
 | maskLimitUp                     | double   | Up percentage limit                                                                             | 10.0              |

--- a/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProvider.java
+++ b/ipv-core/src/main/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProvider.java
@@ -273,9 +273,11 @@ public class DateTimeMaskingProvider extends AbstractMaskingProvider {
       try {
         final DateTimeFormatter fixedFormatter =
             new DateTimeFormatterBuilder().appendPattern(this.fixedFormatString)
-            .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
-            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
-            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter();
+                .parseDefaulting(ChronoField.MONTH_OF_YEAR, 1)
+                .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)
+                .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+                .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter();
         try {
           TemporalAccessor t = fixedFormatter.withZone(ZoneId.systemDefault()).parse(identifier);
           d = Date.from(Instant.from(t));

--- a/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProviderTest.java
+++ b/ipv-core/src/test/java/com/ibm/whc/deid/providers/masking/DateTimeMaskingProviderTest.java
@@ -139,6 +139,36 @@ public class DateTimeMaskingProviderTest extends TestLogSetUp {
   }
 
   @Test
+  public void testMaskFixedFormat_year() throws Exception {
+
+    DateTimeMaskingProviderConfig config = new DateTimeMaskingProviderConfig();
+    config.setFormatFixed("yyyy");
+    config.setYearMask(true);
+    config.setDayMask(false);
+    config.setHourMask(false);
+    config.setMinutesMask(false);
+    config.setSecondsMask(false);
+    config.setMonthMask(false);
+    config.setYearRangeDown(2);
+    config.setYearRangeUp(2);
+
+    DateTimeMaskingProvider maskingProvider = new DateTimeMaskingProvider(config);
+
+    String originalDateTime = "1981";
+    boolean changed = false;
+    for (int i = 0; i < 20; i++) {
+      String maskedDateTime = maskingProvider.mask(originalDateTime);
+      assertNotNull(maskedDateTime);
+      int year = Integer.parseInt(maskedDateTime);
+      assertTrue(1979 <= year && year <= 1983);
+      if (!maskedDateTime.equals(originalDateTime)) {
+        changed = true;
+      }
+    }
+    assertTrue(changed);
+  }
+
+  @Test
   public void testMaskFixedFormat_badInput() throws Exception {
 
     DateTimeMaskingProviderConfig config = new DateTimeMaskingProviderConfig();


### PR DESCRIPTION
Add support for year-only or year-month patterns.  Also changed formatting for certain ordered lists in the documentation.