### PR TITLE
log4j from 2.16 to 2.17.1 for PVR0314138 and PVR0314781

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,13 @@
 
 	<dependencyManagement>
 		<dependencies>
+                        <dependency>
+                               <groupId>org.apache.logging.log4j</groupId>
+                               <artifactId>log4j-bom</artifactId>
+                               <version>2.17.1</version>
+                               <scope>import</scope>
+                               <type>pom</type>
+                        </dependency>
 			<dependency>
 				<!-- Import dependency management from Spring Boot -->
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Confirmed that "mvn dependency:list | grep log4j" does not report the 2.13.3 version anymore after this fix

Before :
$ mvn dependency:list | grep log4j
Downloading from central: https://na.artifactory.swg-devops.com:443/artifactory/wh-de-id-maven-virtual/org/apache/logging/log4j/log4j/2.13.3/log4j-2.13.3.pom
Downloading from releases: https://na.artifactory.swg-devops.com:443/artifactory/wh-de-id-release-maven-local/org/apache/logging/log4j/log4j/2.13.3/log4j-2.13.3.pom
Downloading from izumo-fatjar-artifactory: https://na.artifactory.swg-devops.com/artifactory/wcp-nlp-maven-local/org/apache/logging/log4j/log4j/2.13.3/log4j-2.13.3.pom
[ERROR] Failed to execute goal on project de-identification-app: Could not resolve dependencies for project com.ibm.whc.deid:de-identification-app:jar:1.0.1-SNAPSHOT: Failed to collect dependencies at org.springframework.boot:spring-boot-starter-web:jar:2.4.3 -> org.springframework.boot:spring-boot-starter:jar:2.4.3 -> org.springframework.boot:spring-boot-starter-logging:jar:2.4.3 -> org.apache.logging.log4j:log4j-to-slf4j:jar:2.13.3: Failed to read artifact descriptor for org.apache.logging.log4j:log4j-to-slf4j:jar:2.13.3: Could not find artifact org.apache.logging.log4j:log4j:pom:2.13.3 in central (https://na.artifactory.swg-devops.com:443/artifactory/wh-de-id-maven-virtual) -> [Help 1]

After :
 $ mvn dependency:list | grep log4j
[INFO]    org.apache.logging.log4j:log4j-to-slf4j:jar:2.17.1:compile
[INFO]    org.apache.logging.log4j:log4j-api:jar:2.17.1:compile