### PR TITLE
README updates for first time use

### DIFF
--- a/docs/getting-started-alvearie.md
+++ b/docs/getting-started-alvearie.md
@@ -8,11 +8,9 @@
 To compile the De-Identification server, clone the GIT repository and compile with Maven.
 
 ```
-   export RELEASE=1.1.0   (change to the release you want to build)
    git clone --recurse-submodules https://github.com/Alvearie/de-identification
    cd de-identification/
-   git checkout v${RELEASE}
-   mvn clean package
+   mvn clean install package
 ```
 
  Note: `--recurse-submodules` is required because the repository contains a third-party encryption engine as a Git submodule.  For reference, the
@@ -23,7 +21,7 @@ To compile the De-Identification server, clone the GIT repository and compile wi
  - To start the server, use the following command: 
 
  ```
-   java -jar de-identification-app/target/de-identification-app-${RELEASE}-exec.jar
+   java -jar de-identification-app/target/de-identification-app-*.jar
  ```
 
  - After you start the server, verify that it is running properly. Invoke the health API:
@@ -37,6 +35,16 @@ To compile the De-Identification server, clone the GIT repository and compile wi
  ```
    {"status":"UP"}
  ```
+
+## Build a new version
+The De-Identification service is versioned using the `revision` property within the [Maven POM File](../pom.xml). To build a new version:
+
+```shell
+export DEID_VERSION=1.5.0
+git checkout -b ${DEID_VERSION} 
+# make meaningful code updates and changes
+mvn -Drevision=${DEID_VERSION} clean install package
+````
 
 ## Helm deployment
 You can also deploy a release version of the De-Identification service to a Kubernetes cluster using Helm.  Container images for De-Identification releases are stored on Docker Hub.  For more information, see `de-identification/de-identification-app/chart/README.md`.

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
                             <arg>-Xlint:all</arg>
                             <arg>-Xlint:-processing</arg>
                             <arg>-Xlint:-rawtypes</arg>
+							<arg>-Xlint:-serial </arg>
                             <arg>-Werror</arg>
                         </compilerArgs>
                     </configuration>


### PR DESCRIPTION
This PR updates the project's "getting started" README and pom.xml to resolve some issues I found when cloning the repository for the first time.

Issues
The following warning causes the build to fail since the compiler is set to run with `-Werror` (I'm using OpenJDK 11.0.9.1)

```shell
[WARNING] DateTimeConsistentShiftMaskingProviderConfig.java:[59,24] non-transient instance field of a serializable class declared with a non-serializable type
```

The getting started guide does not include the "install" command for maven.

Changes

- Updated javac via the POM to exclude the non-serializable type warning
- Updated getting started README to use the correct commands.


Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>